### PR TITLE
feat(tf): add Cloud Run deployment with Workload Identity Federation

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,117 @@
+name: Deploy to Cloud Run
+
+on:
+  release:
+    types: [published]
+
+# Prevent concurrent deployments
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT_ID: gtfs-archiver
+  GCP_REGION: us-central1
+  SERVICE_NAME: gtfs-rt-archiver
+  # Image via Artifact Registry remote repo (proxies to GHCR)
+  IMAGE_NAME: us-central1-docker.pkg.dev/gtfs-archiver/ghcr-remote/${{ github.repository }}
+
+jobs:
+  deploy:
+    name: Deploy to Cloud Run
+    runs-on: ubuntu-latest
+    # Only deploy non-prerelease releases
+    if: ${{ !github.event.release.prerelease }}
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/${{ vars.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-actions/providers/github-provider
+          service_account: github-actions-deploy@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Install asdf & tools
+        uses: asdf-vm/actions/install@v4
+
+      - name: Extract version from release tag
+        id: version
+        run: |
+          # Release tag is like v1.2.3
+          VERSION="${{ github.event.release.tag_name }}"
+          # Remove 'v' prefix if present
+          VERSION="${VERSION#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "image=${{ env.IMAGE_NAME }}:$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Verify image exists in GHCR
+        run: |
+          # Check the source image in GHCR (AR remote repo pulls from here on demand)
+          GHCR_IMAGE="ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}"
+          echo "Verifying image: $GHCR_IMAGE"
+          docker manifest inspect "$GHCR_IMAGE" > /dev/null 2>&1 || {
+            echo "Error: Image $GHCR_IMAGE not found in GHCR"
+            exit 1
+          }
+          echo "Image verified in GHCR, AR remote repo will pull on demand"
+
+      - name: Initialize Terraform
+        working-directory: tf
+        run: tofu init
+
+      - name: Plan deployment
+        working-directory: tf
+        run: |
+          tofu plan -concise \
+            -var="container_image=${{ steps.version.outputs.image }}" \
+            -out=tfplan
+
+      - name: Apply deployment
+        working-directory: tf
+        run: tofu apply -concise -auto-approve tfplan
+
+      - name: Verify deployment health
+        run: |
+          SERVICE_URL=$(gcloud run services describe ${{ env.SERVICE_NAME }} \
+            --region=${{ env.GCP_REGION }} \
+            --format='value(status.url)')
+
+          echo "Service URL: $SERVICE_URL"
+          echo "Waiting for service to become healthy..."
+
+          for i in {1..30}; do
+            if curl -sf "${SERVICE_URL}/health" > /dev/null 2>&1; then
+              echo "Service is healthy!"
+              exit 0
+            fi
+            echo "Attempt $i/30: Service not ready yet..."
+            sleep 10
+          done
+
+          echo "Error: Service did not become healthy within 5 minutes"
+          exit 1
+
+      - name: Post deployment summary
+        if: success()
+        run: |
+          SERVICE_URL=$(gcloud run services describe ${{ env.SERVICE_NAME }} \
+            --region=${{ env.GCP_REGION }} \
+            --format='value(status.url)')
+
+          echo "## Deployment Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Version**: ${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Image**: \`${{ steps.version.outputs.image }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Service URL**: ${SERVICE_URL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Health Check**: ${SERVICE_URL}/health" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Metrics**: ${SERVICE_URL}/metrics" >> "$GITHUB_STEP_SUMMARY"

--- a/tf/artifact_registry.tf
+++ b/tf/artifact_registry.tf
@@ -1,0 +1,32 @@
+# Artifact Registry remote repository for GitHub Container Registry
+#
+# Cloud Run cannot pull images directly from GHCR, so we create a remote
+# repository that acts as a pull-through cache/proxy for GHCR images.
+
+resource "google_artifact_registry_repository" "ghcr" {
+  repository_id = "ghcr-remote"
+  location      = var.region
+  project       = var.project_id
+  description   = "Remote repository for GitHub Container Registry"
+  format        = "DOCKER"
+  mode          = "REMOTE_REPOSITORY"
+
+  remote_repository_config {
+    description = "GitHub Container Registry"
+
+    docker_repository {
+      custom_repository {
+        uri = "https://ghcr.io"
+      }
+    }
+  }
+}
+
+# Grant the archiver service account permission to pull from the remote repository
+resource "google_artifact_registry_repository_iam_member" "archiver_reader" {
+  repository = google_artifact_registry_repository.ghcr.name
+  location   = google_artifact_registry_repository.ghcr.location
+  project    = var.project_id
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${google_service_account.archiver.email}"
+}

--- a/tf/outputs.tf
+++ b/tf/outputs.tf
@@ -22,3 +22,13 @@ output "service_account_email" {
   description = "Email of the service account"
   value       = google_service_account.archiver.email
 }
+
+output "workload_identity_provider" {
+  description = "Workload Identity Provider resource name for GitHub Actions"
+  value       = google_iam_workload_identity_pool_provider.github.name
+}
+
+output "github_actions_service_account" {
+  description = "Service account email for GitHub Actions deployments"
+  value       = google_service_account.github_actions.email
+}

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -10,9 +10,9 @@ variable "region" {
 }
 
 variable "container_image" {
-  description = "Container image URL for the archiver"
+  description = "Container image URL for the archiver (via Artifact Registry remote repo)"
   type        = string
-  default     = "us-central1-docker.pkg.dev/gtfs-archiver/gtfs-rt-archiver/gtfs-rt-archiver:latest"
+  default     = "us-central1-docker.pkg.dev/gtfs-archiver/ghcr-remote/jarvusinnovations/gtfs-realtime-archiver:latest"
 }
 
 variable "service_name" {
@@ -78,4 +78,16 @@ variable "secret_env_vars" {
   description = "Map of environment variable names to Secret Manager secret IDs"
   type        = map(string)
   default     = {}
+}
+
+variable "github_org" {
+  description = "GitHub organization for Workload Identity Federation"
+  type        = string
+  default     = "JarvusInnovations"
+}
+
+variable "github_repo" {
+  description = "GitHub repository for Workload Identity Federation"
+  type        = string
+  default     = "gtfs-realtime-archiver"
 }

--- a/tf/wif.tf
+++ b/tf/wif.tf
@@ -1,0 +1,70 @@
+# Workload Identity Federation for GitHub Actions
+#
+# Enables keyless authentication from GitHub Actions to GCP using OIDC tokens.
+# This eliminates the need for service account keys in GitHub Secrets.
+
+# Workload Identity Pool for GitHub Actions
+resource "google_iam_workload_identity_pool" "github" {
+  workload_identity_pool_id = "github-actions"
+  display_name              = "GitHub Actions"
+  description               = "Identity pool for GitHub Actions OIDC authentication"
+  project                   = var.project_id
+}
+
+# Workload Identity Provider for GitHub OIDC
+resource "google_iam_workload_identity_pool_provider" "github" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-provider"
+  display_name                       = "GitHub Provider"
+  project                            = var.project_id
+
+  attribute_mapping = {
+    "google.subject"             = "assertion.sub"
+    "attribute.actor"            = "assertion.actor"
+    "attribute.repository"       = "assertion.repository"
+    "attribute.repository_owner" = "assertion.repository_owner"
+    "attribute.ref"              = "assertion.ref"
+  }
+
+  # Only allow tokens from our specific repository
+  attribute_condition = "assertion.repository_owner == '${var.github_org}' && assertion.repository == '${var.github_org}/${var.github_repo}'"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+# Service account for GitHub Actions deployments
+resource "google_service_account" "github_actions" {
+  account_id   = "github-actions-deploy"
+  display_name = "GitHub Actions Deployment Service Account"
+  project      = var.project_id
+}
+
+# Allow GitHub Actions to impersonate the deployment service account
+resource "google_service_account_iam_member" "github_actions_wif" {
+  service_account_id = google_service_account.github_actions.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_org}/${var.github_repo}"
+}
+
+# Grant Cloud Run Admin to deploy services
+resource "google_project_iam_member" "github_actions_run_admin" {
+  project = var.project_id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:${google_service_account.github_actions.email}"
+}
+
+# Grant ability to act as the archiver service account (required for Cloud Run deployments)
+resource "google_service_account_iam_member" "github_actions_archiver_user" {
+  service_account_id = google_service_account.archiver.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.github_actions.email}"
+}
+
+# Grant access to Terraform state bucket
+resource "google_storage_bucket_iam_member" "github_actions_state" {
+  bucket = "gtfs-archiver-tf-state"
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.github_actions.email}"
+}


### PR DESCRIPTION
Add automated deployment infrastructure for Cloud Run:

- Add Workload Identity Federation for keyless GitHub Actions auth
- Add Artifact Registry remote repository to proxy GHCR images
- Add deployment workflow triggered on non-prerelease releases
- Update container image path to use AR remote repo

WIF is scoped to JarvusInnovations/gtfs-realtime-archiver repository. Cloud Run service will be created on first release when image exists.
