### PR TITLE
chore: reorganize deps into component groups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,14 @@ WORKDIR /app
 # Install dependencies first (for better caching)
 COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-install-project --no-dev
+    uv sync --frozen --no-install-project --only-group archiver
 
 # Copy source and install the project
 COPY README.md ./
 COPY src/ src/
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev
+    uv sync --frozen --only-group archiver && \
+    uv pip install --no-deps -e .
 
 
 # Runtime stage - minimal image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,18 @@ authors = [
     { name = "Chris Alfano", email = "chris@jarv.us" }
 ]
 requires-python = ">=3.12"
-dependencies = [
+dependencies = []
+
+[project.scripts]
+gtfs-rt-archiver = "gtfs_rt_archiver:main"
+
+[build-system]
+requires = ["uv_build>=0.9.21,<0.10.0"]
+build-backend = "uv_build"
+
+[dependency-groups]
+# Component-specific groups
+archiver = [
     "aiohttp>=3.13.2",
     "apscheduler>=4.0.0a6",
     "gcloud-aio-storage>=9.6.1",
@@ -21,23 +32,20 @@ dependencies = [
     "structlog>=25.5.0",
     "tenacity>=9.1.2",
 ]
-
-[project.scripts]
-gtfs-rt-archiver = "gtfs_rt_archiver:main"
-
-[build-system]
-requires = ["uv_build>=0.9.21,<0.10.0"]
-build-backend = "uv_build"
-
-[dependency-groups]
-dev = [
-    "mypy>=1.19.1",
+dev-archiver = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.0.0",
     "respx>=0.22.0",
-    "ruff>=0.14.10",
     "types-pyyaml>=6.0.12.20250915",
+]
+
+# Aggregate groups - includes component groups for local dev
+dev = [
+    { include-group = "archiver" },
+    { include-group = "dev-archiver" },
+    "mypy>=1.19.1",
+    "ruff>=0.14.10",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -721,7 +721,9 @@ wheels = [
 name = "gtfs-rt-archiver"
 version = "0.1.0"
 source = { editable = "." }
-dependencies = [
+
+[package.dev-dependencies]
+archiver = [
     { name = "aiohttp" },
     { name = "apscheduler" },
     { name = "gcloud-aio-storage" },
@@ -734,20 +736,38 @@ dependencies = [
     { name = "structlog" },
     { name = "tenacity" },
 ]
-
-[package.dev-dependencies]
 dev = [
+    { name = "aiohttp" },
+    { name = "apscheduler" },
+    { name = "gcloud-aio-storage" },
+    { name = "google-cloud-secret-manager" },
+    { name = "httpx" },
     { name = "mypy" },
+    { name = "prometheus-client" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pyyaml" },
+    { name = "respx" },
+    { name = "ruff" },
+    { name = "structlog" },
+    { name = "tenacity" },
+    { name = "types-pyyaml" },
+]
+dev-archiver = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "respx" },
-    { name = "ruff" },
     { name = "types-pyyaml" },
 ]
 
 [package.metadata]
-requires-dist = [
+
+[package.metadata.requires-dev]
+archiver = [
     { name = "aiohttp", specifier = ">=3.13.2" },
     { name = "apscheduler", specifier = ">=4.0.0a6" },
     { name = "gcloud-aio-storage", specifier = ">=9.6.1" },
@@ -760,15 +780,31 @@ requires-dist = [
     { name = "structlog", specifier = ">=25.5.0" },
     { name = "tenacity", specifier = ">=9.1.2" },
 ]
-
-[package.metadata.requires-dev]
 dev = [
+    { name = "aiohttp", specifier = ">=3.13.2" },
+    { name = "apscheduler", specifier = ">=4.0.0a6" },
+    { name = "gcloud-aio-storage", specifier = ">=9.6.1" },
+    { name = "google-cloud-secret-manager", specifier = ">=2.26.0" },
+    { name = "httpx", specifier = ">=0.28.0,<1.0" },
     { name = "mypy", specifier = ">=1.19.1" },
+    { name = "prometheus-client", specifier = ">=0.23.1" },
+    { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "pydantic-settings", specifier = ">=2.12.0" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "respx", specifier = ">=0.22.0" },
+    { name = "ruff", specifier = ">=0.14.10" },
+    { name = "structlog", specifier = ">=25.5.0" },
+    { name = "tenacity", specifier = ">=9.1.2" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
+]
+dev-archiver = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "respx", specifier = ">=0.22.0" },
-    { name = "ruff", specifier = ">=0.14.10" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 


### PR DESCRIPTION
Move archiver-specific dependencies into named groups to support multiple components in the repository:

- archiver: runtime deps for gtfs_rt_archiver
- dev-archiver: test deps specific to archiver (pytest, respx, etc.)
- dev: aggregate group including archiver + dev-archiver + shared tools

Update Dockerfile to install only the archiver group with --only-group archiver flag.
