### PR TITLE
feat(archiver): add production-aligned delay and processing metrics

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -69,8 +69,9 @@ class TestCreateFetchJob:
         async with httpx.AsyncClient() as client:
             semaphore = asyncio.Semaphore(10)
             fetch_job = await create_fetch_job(client, mock_storage_writer, semaphore)
+            scheduled_time = datetime.now(UTC)
 
-            await fetch_job(feed_config)
+            await fetch_job(feed_config, scheduled_time)
 
         # Verify storage was called
         mock_storage_writer.write.assert_called_once()
@@ -96,7 +97,8 @@ class TestCreateFetchJob:
             async with httpx.AsyncClient() as client:
                 semaphore = asyncio.Semaphore(10)
                 fetch_job = await create_fetch_job(client, mock_storage_writer, semaphore)
-                await fetch_job(feed_config)
+                scheduled_time = datetime.now(UTC)
+                await fetch_job(feed_config, scheduled_time)
 
             mock_attempt.assert_called_once_with("test-feed", "vehicle_positions", "test-agency")
             mock_success.assert_called_once()
@@ -117,9 +119,10 @@ class TestCreateFetchJob:
             async with httpx.AsyncClient() as client:
                 semaphore = asyncio.Semaphore(10)
                 fetch_job = await create_fetch_job(client, mock_storage_writer, semaphore)
+                scheduled_time = datetime.now(UTC)
 
                 # Should not raise
-                await fetch_job(feed_config)
+                await fetch_job(feed_config, scheduled_time)
 
             mock_error.assert_called_once()
             args = mock_error.call_args[0]
@@ -141,9 +144,10 @@ class TestCreateFetchJob:
             async with httpx.AsyncClient() as client:
                 semaphore = asyncio.Semaphore(10)
                 fetch_job = await create_fetch_job(client, mock_storage_writer, semaphore)
+                scheduled_time = datetime.now(UTC)
 
                 # Should not raise
-                await fetch_job(feed_config)
+                await fetch_job(feed_config, scheduled_time)
 
             mock_error.assert_called_once()
             args = mock_error.call_args[0]
@@ -164,9 +168,10 @@ class TestCreateFetchJob:
             async with httpx.AsyncClient() as client:
                 semaphore = asyncio.Semaphore(10)
                 fetch_job = await create_fetch_job(client, mock_storage_writer, semaphore)
+                scheduled_time = datetime.now(UTC)
 
                 # Should not raise
-                await fetch_job(feed_config)
+                await fetch_job(feed_config, scheduled_time)
 
             mock_error.assert_called_once()
             args = mock_error.call_args[0]
@@ -197,9 +202,10 @@ class TestCreateFetchJob:
             async with httpx.AsyncClient() as client:
                 semaphore = asyncio.Semaphore(10)
                 fetch_job = await create_fetch_job(client, mock_storage_writer, semaphore)
+                scheduled_time = datetime.now(UTC)
 
                 # Should not raise
-                await fetch_job(feed)
+                await fetch_job(feed, scheduled_time)
 
             mock_error.assert_called_once()
             args = mock_error.call_args[0]
@@ -222,9 +228,10 @@ class TestCreateFetchJob:
             async with httpx.AsyncClient() as client:
                 semaphore = asyncio.Semaphore(10)
                 fetch_job = await create_fetch_job(client, mock_storage, semaphore)
+                scheduled_time = datetime.now(UTC)
 
                 # Should not raise
-                await fetch_job(feed_config)
+                await fetch_job(feed_config, scheduled_time)
 
             mock_error.assert_called_once()
             args = mock_error.call_args[0]
@@ -245,6 +252,7 @@ class TestCreateFetchJob:
             # Semaphore with limit of 2
             semaphore = asyncio.Semaphore(2)
             fetch_job = await create_fetch_job(client, mock_storage_writer, semaphore)
+            scheduled_time = datetime.now(UTC)
 
             # Track concurrent executions
             max_concurrent = 0
@@ -273,7 +281,7 @@ class TestCreateFetchJob:
                 for i in range(5)
             ]
 
-            await asyncio.gather(*[fetch_job(f) for f in feeds])
+            await asyncio.gather(*[fetch_job(f, scheduled_time) for f in feeds])
 
             # Max concurrent should not exceed semaphore limit
             assert max_concurrent <= 2
@@ -291,9 +299,10 @@ class TestCreateFetchJob:
             async with httpx.AsyncClient() as client:
                 semaphore = asyncio.Semaphore(10)
                 fetch_job = await create_fetch_job(client, mock_storage_writer, semaphore)
+                scheduled_time = datetime.now(UTC)
 
                 # Should not raise
-                await fetch_job(feed_config)
+                await fetch_job(feed_config, scheduled_time)
 
             mock_error.assert_called_once()
             args = mock_error.call_args[0]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,5 +1,7 @@
 """Tests for scheduler module."""
 
+from datetime import datetime
+
 import pytest
 
 from gtfs_rt_archiver.models import FeedConfig
@@ -103,7 +105,7 @@ class TestFeedScheduler:
         """Create a mock fetch job that tracks calls."""
         calls: list[FeedConfig] = []
 
-        async def fetch_job(feed: FeedConfig) -> None:
+        async def fetch_job(feed: FeedConfig, _scheduled_time: datetime) -> None:
             calls.append(feed)
 
         # Return the calls list but attach the function
@@ -113,7 +115,7 @@ class TestFeedScheduler:
     def test_initialization(self, feeds: list[FeedConfig]) -> None:
         """Test scheduler initialization."""
 
-        async def dummy_job(feed: FeedConfig) -> None:
+        async def dummy_job(_feed: FeedConfig, _scheduled_time: datetime) -> None:
             pass
 
         scheduler = FeedScheduler(
@@ -131,7 +133,7 @@ class TestFeedScheduler:
         """Test scheduler start and stop lifecycle."""
         calls: list[FeedConfig] = []
 
-        async def fetch_job(feed: FeedConfig) -> None:
+        async def fetch_job(feed: FeedConfig, _scheduled_time: datetime) -> None:
             calls.append(feed)
 
         scheduler = FeedScheduler(
@@ -156,7 +158,7 @@ class TestFeedScheduler:
     async def test_start_filters_feeds_by_shard(self, feeds: list[FeedConfig]) -> None:
         """Test that start() filters feeds based on shard assignment."""
 
-        async def fetch_job(feed: FeedConfig) -> None:
+        async def fetch_job(_feed: FeedConfig, _scheduled_time: datetime) -> None:
             pass
 
         # Create scheduler for shard 0 of 2
@@ -177,7 +179,7 @@ class TestFeedScheduler:
     async def test_stop_without_start(self) -> None:
         """Test that stop() is safe to call without start()."""
 
-        async def fetch_job(feed: FeedConfig) -> None:
+        async def fetch_job(_feed: FeedConfig, _scheduled_time: datetime) -> None:
             pass
 
         scheduler = FeedScheduler(
@@ -192,7 +194,7 @@ class TestFeedScheduler:
         """Test run_once executes the fetch job for a feed."""
         calls: list[FeedConfig] = []
 
-        async def fetch_job(feed: FeedConfig) -> None:
+        async def fetch_job(feed: FeedConfig, _scheduled_time: datetime) -> None:
             calls.append(feed)
 
         scheduler = FeedScheduler(
@@ -209,7 +211,7 @@ class TestFeedScheduler:
     async def test_is_running_reflects_scheduler_state(self, feeds: list[FeedConfig]) -> None:
         """Test is_running property reflects actual scheduler state."""
 
-        async def fetch_job(feed: FeedConfig) -> None:
+        async def fetch_job(_feed: FeedConfig, _scheduled_time: datetime) -> None:
             pass
 
         scheduler = FeedScheduler(
@@ -233,7 +235,7 @@ class TestCreateAndStartScheduler:
         """Test that factory creates and starts a scheduler."""
         feeds = [make_feed("test-feed")]
 
-        async def fetch_job(feed: FeedConfig) -> None:
+        async def fetch_job(_feed: FeedConfig, _scheduled_time: datetime) -> None:
             pass
 
         scheduler = await create_and_start_scheduler(
@@ -251,7 +253,7 @@ class TestCreateAndStartScheduler:
         """Test factory with sharding parameters."""
         feeds = [make_feed(f"feed-{i}") for i in range(10)]
 
-        async def fetch_job(feed: FeedConfig) -> None:
+        async def fetch_job(_feed: FeedConfig, _scheduled_time: datetime) -> None:
             pass
 
         scheduler = await create_and_start_scheduler(


### PR DESCRIPTION
Add metrics from production v3 archiver for better observability:

Delay/slippage metrics (3 histograms for bottleneck diagnosis):
- gtfs_rt_scheduler_delay_seconds: APScheduler dispatch overhead
- gtfs_rt_queue_delay_seconds: semaphore wait time
- gtfs_rt_total_delay_seconds: combined scheduler + queue delay

Processing metrics:
- gtfs_rt_processing_time_seconds: end-to-end fetch + upload time
- gtfs_rt_processed_bytes_total: cumulative bytes with content_type label
- gtfs_rt_upload_total: upload attempts counter

Scheduler now passes scheduled_fire_time from APScheduler job context to enable accurate delay measurement.
