### PR TITLE
feat(tf): add consolidated Dagster deployment mode

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -370,6 +370,25 @@ The module supports two topologies, selected via `dagster_deployment_mode`
   the active one; the database, buckets, secrets, run-worker job, and service
   accounts are shared across both.
 
+  **Cost break-even**: at the default sizing (containers summing to 1 vCPU / 2Gi)
+  the consolidated instance runs ~$55/mo — vs ~$100/mo idle for the split topology
+  (always-on daemon + daemon-kept-warm code server). Sized up to 2 vCPU / 2.5Gi it
+  is ~$105–110/mo, a wash against split. Consolidation saves money only at roughly
+  ≤1.5 vCPU total; see the note on `consolidated_resources` in
+  `tf/modules/dagster/variables.tf`.
+
+**Terraform image variables move with releases — never apply with stale ones**:
+
+The release workflow (`.github/workflows/deploy.yaml`) deploys by running
+`tofu apply` with `-var` image values derived from the release tag. Terraform
+*is* the image mover, so the image fields deliberately have **no**
+`lifecycle ignore_changes` (that would silently break CI deploys). The corollary:
+a local `tofu plan`/`apply` that doesn't pass the currently-deployed image
+versions will show (and would roll back!) image "downgrades" to whatever stale
+values are in tfvars/defaults. Before any local apply, derive the image vars from
+the latest release tag (as deploy.yaml does), pass `-target` for the resources
+you're changing, or confirm the plan shows no image changes.
+
 ## Testing Container Builds
 
 **When to test locally**:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -70,9 +70,10 @@ gtfs-realtime-archiver/
 │   ├── dagster.tf          # Dagster module instantiation
 │   ├── modules/dagster/    # Dagster deployment module
 │   │   ├── main.tf         # Module locals and config
-│   │   ├── webserver.tf    # Dagster UI (Cloud Run Service)
-│   │   ├── daemon.tf       # Dagster daemon (Worker Pool)
-│   │   ├── code_server.tf  # gRPC code servers
+│   │   ├── webserver.tf    # Dagster UI (Cloud Run Service, split mode)
+│   │   ├── daemon.tf       # Dagster daemon (Worker Pool, split mode)
+│   │   ├── code_server.tf  # gRPC code servers (split mode)
+│   │   ├── consolidated.tf # Single-instance web+daemon+code (consolidated mode)
 │   │   ├── run_worker.tf   # Cloud Run Jobs for runs
 │   │   ├── iam.tf          # Service accounts and permissions
 │   │   ├── secrets.tf      # DB password secret
@@ -338,6 +339,36 @@ Each location gets:
 - Dedicated code server (gRPC)
 - Dedicated run worker job
 - Dedicated service account with specific IAM permissions
+
+**Deployment Topologies** (`deployment_mode` variable):
+
+The module supports two topologies, selected via `dagster_deployment_mode`
+(root) / `deployment_mode` (module). Default is `split`.
+
+- **`split`** (default): webserver, daemon, and code server each run as their
+  own Cloud Run resource (Service / Worker Pool / Service). The webserver scales
+  0→N and the code server is isolated so code reloads don't affect the host
+  processes. Use when you need horizontal UI scaling or multiple code locations.
+
+- **`consolidated`**: webserver (ingress) + daemon + code server run as three
+  containers in **one always-on Cloud Run Service instance** (`consolidated.tf`),
+  for a single code location. Lowest cost floor — collapses what is otherwise two
+  always-on footprints (daemon + daemon-kept-warm code server) into one. Run
+  workers are unchanged (still per-run Cloud Run Jobs).
+
+  Constraints baked into the consolidated service:
+  - `max_instance_count = 1` — the daemon must be a singleton (a second instance
+    would double-fire schedules/sensors).
+  - `cpu_idle = false` (instance-based billing) — in a request-billed Service,
+    sidecars only get CPU while the ingress handles a request, which starves the
+    always-on daemon. Always-allocated CPU is required.
+  - The code server is reached over `localhost` (`CODE_SERVER_HOST_<LOC>=localhost`,
+    port from `deploy/workspace.yaml`); no internal code-server Service is created.
+
+  Flip topologies with `dagster_deployment_mode = "consolidated"` in tfvars and
+  `tofu apply`. Switching destroys the resources of the other topology and creates
+  the active one; the database, buckets, secrets, run-worker job, and service
+  accounts are shared across both.
 
 ## Testing Container Builds
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -358,7 +358,10 @@ The module supports two topologies, selected via `dagster_deployment_mode`
 
   Constraints baked into the consolidated service:
   - `max_instance_count = 1` — the daemon must be a singleton (a second instance
-    would double-fire schedules/sensors).
+    would double-fire schedules/sensors). Caveat: unlike the split Worker Pool's
+    MANUAL scaling, a Service revision rollout can briefly run old + new instances
+    concurrently, so the daemon may transiently double-fire during deploys —
+    acceptable for idempotent schedules, worth knowing about.
   - `cpu_idle = false` (instance-based billing) — in a request-billed Service,
     sidecars only get CPU while the ingress handles a request, which starves the
     always-on daemon. Always-allocated CPU is required.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -952,12 +952,22 @@ tofu apply -var-file=prod.tfvars
 tofu destroy -var-file=prod.tfvars
 ```
 
+The Dagster deployment supports two topologies via `dagster_deployment_mode`:
+`split` (default; each component its own Cloud Run resource) and `consolidated`
+(webserver + daemon + code server as three containers in one always-on instance —
+lowest cost floor, single code location only). Constraints and cost break-even are
+documented in "Deployment Topologies" in `.claude/CLAUDE.md`.
+
+Note that releases deploy by running `tofu apply` with image `-var`s derived from
+the release tag (see `.github/workflows/deploy.yaml`) — local applies must supply
+current image versions or they will roll deployed images back.
+
 ---
 
 ## Appendix A: Dependency Justification
 
 | Dependency | Purpose | Alternatives Considered |
-|------------|---------|------------------------|
+| ------------ | --------- | ------------------------ |
 | **httpx** | Async HTTP client | aiohttp (less ergonomic), requests (sync only) |
 | **apscheduler** | In-process job scheduling | schedule (no async), celery (overkill) |
 | **pydantic** | Data validation & settings | attrs (less features), dataclasses (no validation) |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -967,7 +967,7 @@ current image versions or they will roll deployed images back.
 ## Appendix A: Dependency Justification
 
 | Dependency | Purpose | Alternatives Considered |
-| ------------ | --------- | ------------------------ |
+|------------|---------|------------------------|
 | **httpx** | Async HTTP client | aiohttp (less ergonomic), requests (sync only) |
 | **apscheduler** | In-process job scheduling | schedule (no async), celery (overkill) |
 | **pydantic** | Data validation & settings | attrs (less features), dataclasses (no validation) |

--- a/README.md
+++ b/README.md
@@ -334,6 +334,15 @@ Required for Dagster:
 - `GCS_BUCKET_RT_PROTOBUF`: Source bucket with protobuf archives
 - `GCS_BUCKET_RT_PARQUET`: Target bucket for parquet output
 
+### Deployment topology
+
+The Cloud Run deployment supports two topologies via the `dagster_deployment_mode`
+Terraform variable: `split` (default — webserver, daemon, and code server as
+separate Cloud Run resources) and `consolidated` (all three as containers in one
+always-on instance, for the lowest cost floor with a single code location). See
+"Deployment Topologies" in `.claude/CLAUDE.md` for constraints and cost
+break-even details.
+
 ## License
 
 AGPL-3.0

--- a/tf/dagster.tf
+++ b/tf/dagster.tf
@@ -16,6 +16,8 @@ module "dagster" {
   parquet_bucket_name  = google_storage_bucket.parquet.name
   agencies_secret_id   = var.agencies_secret_id
 
+  deployment_mode = var.dagster_deployment_mode
+
   webserver_image = var.dagster_webserver_image
   daemon_image    = var.dagster_daemon_image
 

--- a/tf/modules/dagster/code_server.tf
+++ b/tf/modules/dagster/code_server.tf
@@ -2,7 +2,8 @@
 # One service per code location
 
 resource "google_cloud_run_v2_service" "code_server" {
-  for_each = var.code_locations
+  # Only created in split mode; consolidated mode runs the code server as a sidecar
+  for_each = local.is_split ? var.code_locations : {}
 
   name     = "dagster-code-server-${each.key}"
   location = var.region

--- a/tf/modules/dagster/consolidated.tf
+++ b/tf/modules/dagster/consolidated.tf
@@ -6,7 +6,7 @@
 # Created only when var.deployment_mode == "consolidated". In that mode the split
 # webserver Service, daemon Worker Pool, and code-server Service are not created.
 #
-# Key constraints (see DESIGN.md "Deployment topologies"):
+# Key constraints (see CLAUDE.md "Deployment Topologies"):
 #   - max_instance_count = 1: the daemon must be a singleton. A second instance
 #     would double-fire schedules and double-evaluate sensors.
 #   - cpu_idle = false (instance-based billing): in a request-billed Service,
@@ -107,7 +107,9 @@ resource "google_cloud_run_v2_service" "consolidated" {
         cpu_idle = false # instance-based billing (always-allocated CPU)
       }
 
-      # gRPC startup probe - gates the webserver/daemon container start order
+      # gRPC startup probe - gates the webserver/daemon container start order.
+      # Cloud Run requires timeout_seconds <= period_seconds (matches the split
+      # code_server.tf probe); threshold 4 keeps the ~2 minute startup budget.
       startup_probe {
         grpc {
           port    = local.consolidated_location.port
@@ -115,8 +117,8 @@ resource "google_cloud_run_v2_service" "consolidated" {
         }
         initial_delay_seconds = 0
         timeout_seconds       = 30
-        period_seconds        = 10
-        failure_threshold     = 12
+        period_seconds        = 30
+        failure_threshold     = 4
       }
     }
 
@@ -246,4 +248,14 @@ resource "google_cloud_run_v2_service" "consolidated" {
   depends_on = [
     google_secret_manager_secret_iam_member.dagster_postgres_url
   ]
+
+  lifecycle {
+    # Consolidated mode co-locates exactly one code server. With more locations,
+    # only the first would be wired in while run_worker.tf still creates Jobs for
+    # all of them — fail fast instead of half-deploying.
+    precondition {
+      condition     = length(var.code_locations) == 1
+      error_message = "deployment_mode = \"consolidated\" supports exactly one code location; var.code_locations has ${length(var.code_locations)} entries. Use deployment_mode = \"split\" for multiple code locations."
+    }
+  }
 }

--- a/tf/modules/dagster/consolidated.tf
+++ b/tf/modules/dagster/consolidated.tf
@@ -1,0 +1,249 @@
+# Consolidated single-instance Dagster deployment (minimal cost floor / "rung 1").
+#
+# Runs the webserver (ingress), daemon, and code server as three containers in ONE
+# always-on Cloud Run Service instance, for a single code location.
+#
+# Created only when var.deployment_mode == "consolidated". In that mode the split
+# webserver Service, daemon Worker Pool, and code-server Service are not created.
+#
+# Key constraints (see DESIGN.md "Deployment topologies"):
+#   - max_instance_count = 1: the daemon must be a singleton. A second instance
+#     would double-fire schedules and double-evaluate sensors.
+#   - cpu_idle = false (instance-based billing): in a request-billed Service,
+#     sidecars only receive CPU while the ingress container is handling a request,
+#     which would starve the always-on daemon between UI requests. Always-allocated
+#     CPU is required for the daemon to tick reliably.
+#   - Inter-container traffic is over localhost. The code server listens on its
+#     configured port (3030, matching deploy/workspace.yaml); the webserver and
+#     daemon reach it at CODE_SERVER_HOST_<LOC> = "localhost". No separate internal
+#     code-server Service is created, and no gRPC traffic leaves the instance.
+#   - Run workers are unaffected: they are still launched per-run as Cloud Run Jobs
+#     by the CloudRunRunLauncher (see run_worker.tf).
+
+resource "google_cloud_run_v2_service" "consolidated" {
+  count = local.is_consolidated ? 1 : 0
+
+  # Use beta provider for IAP support (parity with the split webserver)
+  provider = google-beta
+
+  name     = "dagster"
+  location = var.region
+  project  = var.project_id
+
+  # Enable IAP (Preview feature) - requires BETA launch stage
+  launch_stage = var.iap_allowed_domain != null ? "BETA" : null
+  iap_enabled  = var.iap_allowed_domain != null
+
+  # Allow external access to the UI
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  deletion_protection = false
+
+  labels = local.common_labels
+
+  template {
+    service_account = google_service_account.dagster.email
+
+    # Single always-on instance: the daemon must be unique.
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 1
+    }
+
+    # Cloud SQL volume mount for Unix socket connection (shared by all containers)
+    volumes {
+      name = "cloudsql"
+      cloud_sql_instance {
+        instances = [var.cloud_sql_connection_name]
+      }
+    }
+
+    # --- Code server (gRPC; started first via container dependency) ---
+    containers {
+      name  = "code-server"
+      image = local.consolidated_location.image
+
+      command = [
+        "dagster", "api", "grpc",
+        "--host", "0.0.0.0",
+        "--port", tostring(local.consolidated_location.port),
+        "--module-name", local.consolidated_location.module_name,
+      ]
+
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
+
+      dynamic "env" {
+        for_each = local.common_env
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      env {
+        name = "DAGSTER_POSTGRES_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.postgres_url.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      # Current image so Dagster tags runs / run workers with the right image
+      env {
+        name  = "DAGSTER_CURRENT_IMAGE"
+        value = local.consolidated_location.image
+      }
+
+      resources {
+        limits = {
+          cpu    = var.consolidated_resources.code_server.cpu
+          memory = var.consolidated_resources.code_server.memory
+        }
+        cpu_idle = false # instance-based billing (always-allocated CPU)
+      }
+
+      # gRPC startup probe - gates the webserver/daemon container start order
+      startup_probe {
+        grpc {
+          port    = local.consolidated_location.port
+          service = "DagsterApi"
+        }
+        initial_delay_seconds = 0
+        timeout_seconds       = 30
+        period_seconds        = 10
+        failure_threshold     = 12
+      }
+    }
+
+    # --- Webserver (ingress container, HTTP 3000) ---
+    containers {
+      name       = "webserver"
+      image      = var.webserver_image
+      depends_on = ["code-server"]
+
+      command = ["dagster-webserver", "--host", "0.0.0.0", "--port", "3000"]
+
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
+
+      dynamic "env" {
+        for_each = local.common_env
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      # Code server is co-located: reach it over localhost.
+      # deploy/workspace.yaml pins the port (3030), so only the host is supplied.
+      env {
+        name  = "CODE_SERVER_HOST_${upper(local.consolidated_location_key)}"
+        value = "localhost"
+      }
+
+      env {
+        name = "DAGSTER_POSTGRES_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.postgres_url.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      ports {
+        name           = "http1"
+        container_port = 3000
+      }
+
+      resources {
+        limits = {
+          cpu    = var.consolidated_resources.webserver.cpu
+          memory = var.consolidated_resources.webserver.memory
+        }
+        cpu_idle          = false
+        startup_cpu_boost = true
+      }
+
+      startup_probe {
+        http_get {
+          path = "/server_info"
+          port = 3000
+        }
+        initial_delay_seconds = 5
+        timeout_seconds       = 5
+        period_seconds        = 10
+        failure_threshold     = 12 # 2 minutes startup time
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/server_info"
+          port = 3000
+        }
+        period_seconds    = 30
+        timeout_seconds   = 5
+        failure_threshold = 3
+      }
+    }
+
+    # --- Daemon (sidecar; scheduler, sensors, run queue, run monitoring) ---
+    containers {
+      name       = "daemon"
+      image      = var.daemon_image
+      depends_on = ["code-server"]
+
+      command = ["dagster-daemon", "run"]
+
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
+
+      dynamic "env" {
+        for_each = local.common_env
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      env {
+        name  = "CODE_SERVER_HOST_${upper(local.consolidated_location_key)}"
+        value = "localhost"
+      }
+
+      env {
+        name = "DAGSTER_POSTGRES_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.postgres_url.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      resources {
+        limits = {
+          cpu    = var.consolidated_resources.daemon.cpu
+          memory = var.consolidated_resources.daemon.memory
+        }
+        cpu_idle = false # always-allocated so the daemon ticks without UI traffic
+      }
+
+      # No liveness probe - dagster-daemon exposes no HTTP/TCP endpoint.
+      # Cloud Run's automatic restart handles daemon crashes.
+    }
+  }
+
+  depends_on = [
+    google_secret_manager_secret_iam_member.dagster_postgres_url
+  ]
+}

--- a/tf/modules/dagster/consolidated.tf
+++ b/tf/modules/dagster/consolidated.tf
@@ -105,6 +105,10 @@ resource "google_cloud_run_v2_service" "consolidated" {
           memory = var.consolidated_resources.code_server.memory
         }
         cpu_idle = false # instance-based billing (always-allocated CPU)
+        # Boost bills only during startup; without it a fractional-CPU code server
+        # importing heavy definitions can blow the 120s startup-probe budget and
+        # wedge the whole instance (webserver/daemon depends_on this container).
+        startup_cpu_boost = true
       }
 
       # gRPC startup probe - gates the webserver/daemon container start order.
@@ -237,7 +241,8 @@ resource "google_cloud_run_v2_service" "consolidated" {
           cpu    = var.consolidated_resources.daemon.cpu
           memory = var.consolidated_resources.daemon.memory
         }
-        cpu_idle = false # always-allocated so the daemon ticks without UI traffic
+        cpu_idle          = false # always-allocated so the daemon ticks without UI traffic
+        startup_cpu_boost = true  # boost bills only during startup
       }
 
       # No liveness probe - dagster-daemon exposes no HTTP/TCP endpoint.

--- a/tf/modules/dagster/daemon.tf
+++ b/tf/modules/dagster/daemon.tf
@@ -2,6 +2,9 @@
 # Worker Pools are designed for continuous background work without HTTP endpoints
 
 resource "google_cloud_run_v2_worker_pool" "daemon" {
+  # Only created in split mode; consolidated mode runs the daemon as a sidecar
+  count = local.is_split ? 1 : 0
+
   name     = "dagster-daemon"
   location = var.region
   project  = var.project_id

--- a/tf/modules/dagster/main.tf
+++ b/tf/modules/dagster/main.tf
@@ -12,6 +12,20 @@ locals {
     component  = "dagster"
   })
 
+  # Deployment topology toggles (see var.deployment_mode)
+  is_consolidated = var.deployment_mode == "consolidated"
+  is_split        = var.deployment_mode == "split"
+
+  # Consolidated mode co-locates a single code location. Pick the (only) entry.
+  consolidated_location_key = try(keys(var.code_locations)[0], null)
+  consolidated_location     = try(var.code_locations[local.consolidated_location_key], null)
+
+  # The Service that carries the webserver ingress, used to wire IAP, the public
+  # invoker, and the custom domain mapping in both modes. Splats + one() stay safe
+  # when the non-active resource has count = 0.
+  webserver_service_name = local.is_consolidated ? one(google_cloud_run_v2_service.consolidated[*].name) : one(google_cloud_run_v2_service.webserver[*].name)
+  webserver_service_uri  = local.is_consolidated ? one(google_cloud_run_v2_service.consolidated[*].uri) : one(google_cloud_run_v2_service.webserver[*].uri)
+
   # Use provided logs bucket or create one
   logs_bucket_name = var.logs_bucket_name != null ? var.logs_bucket_name : google_storage_bucket.logs[0].name
 

--- a/tf/modules/dagster/outputs.tf
+++ b/tf/modules/dagster/outputs.tf
@@ -1,12 +1,17 @@
 # Webserver outputs
+output "deployment_mode" {
+  description = "Active Dagster deployment topology (split or consolidated)"
+  value       = var.deployment_mode
+}
+
 output "webserver_url" {
   description = "URL of the Dagster webserver (Cloud Run URL)"
-  value       = google_cloud_run_v2_service.webserver.uri
+  value       = local.webserver_service_uri
 }
 
 output "webserver_service_name" {
-  description = "Name of the webserver Cloud Run service"
-  value       = google_cloud_run_v2_service.webserver.name
+  description = "Name of the Cloud Run service serving the Dagster webserver"
+  value       = local.webserver_service_name
 }
 
 output "webserver_iap_url" {

--- a/tf/modules/dagster/variables.tf
+++ b/tf/modules/dagster/variables.tf
@@ -74,18 +74,27 @@ variable "deployment_mode" {
 
 # Per-container resource limits for the consolidated deployment.
 # The instance total is the SUM across the three containers and must resolve to a
-# supported Cloud Run CPU size. Defaults sum to 2 vCPU / 2.5Gi.
+# supported Cloud Run CPU size. Defaults sum to 1 vCPU / 2Gi.
+#
+# Cost break-even (us-central1, always-allocated, no CUD): a consolidated instance
+# runs ~$55/mo at the 1 vCPU default but ~$105-110/mo at 2 vCPU / 2.5Gi — the
+# latter is a wash against a loaded split deployment's idle floor (~$100/mo:
+# always-on daemon + daemon-kept-warm code server). Consolidation only *saves*
+# money at roughly <=1.5 vCPU total; above that it's a topology simplification,
+# not a cost cut. Size up only if the UI or code server is actually starved.
+# If Cloud Run rejects the fractional per-container split at apply time, fall
+# back to whole-CPU containers (1000m each, 3 vCPU total).
 variable "consolidated_resources" {
-  description = "Per-container resource limits for deployment_mode = consolidated"
+  description = "Per-container resource limits for deployment_mode = consolidated. Instance cost scales with the SUM across containers; see the break-even note above this variable."
   type = object({
     webserver   = object({ cpu = string, memory = string })
     daemon      = object({ cpu = string, memory = string })
     code_server = object({ cpu = string, memory = string })
   })
   default = {
-    webserver   = { cpu = "1000m", memory = "1Gi" }
-    code_server = { cpu = "500m", memory = "1Gi" }
-    daemon      = { cpu = "500m", memory = "512Mi" }
+    webserver   = { cpu = "500m", memory = "512Mi" }
+    code_server = { cpu = "250m", memory = "1Gi" }
+    daemon      = { cpu = "250m", memory = "512Mi" }
   }
 }
 

--- a/tf/modules/dagster/variables.tf
+++ b/tf/modules/dagster/variables.tf
@@ -47,6 +47,48 @@ variable "code_locations" {
   }))
 }
 
+# Deployment topology
+variable "deployment_mode" {
+  description = <<-EOT
+    Dagster topology:
+      - "split"        (default): webserver, daemon, and code server each run as
+                       their own Cloud Run resource. Webserver scales 0->N, daemon
+                       is a single-instance Worker Pool, code server is isolated.
+                       Use when you need horizontal UI scaling or multiple code
+                       locations.
+      - "consolidated": webserver (ingress) + daemon + code server run as three
+                       containers in ONE always-on Cloud Run Service instance.
+                       Lowest cost floor; single code location only. The instance
+                       is pinned to exactly 1 (daemon must be a singleton) and uses
+                       instance-based billing (always-allocated CPU) so the daemon
+                       sidecar is not starved between UI requests.
+  EOT
+  type        = string
+  default     = "split"
+
+  validation {
+    condition     = contains(["split", "consolidated"], var.deployment_mode)
+    error_message = "deployment_mode must be either \"split\" or \"consolidated\"."
+  }
+}
+
+# Per-container resource limits for the consolidated deployment.
+# The instance total is the SUM across the three containers and must resolve to a
+# supported Cloud Run CPU size. Defaults sum to 2 vCPU / 2.5Gi.
+variable "consolidated_resources" {
+  description = "Per-container resource limits for deployment_mode = consolidated"
+  type = object({
+    webserver   = object({ cpu = string, memory = string })
+    daemon      = object({ cpu = string, memory = string })
+    code_server = object({ cpu = string, memory = string })
+  })
+  default = {
+    webserver   = { cpu = "1000m", memory = "1Gi" }
+    code_server = { cpu = "500m", memory = "1Gi" }
+    daemon      = { cpu = "500m", memory = "512Mi" }
+  }
+}
+
 # Optional variables with defaults
 variable "db_name" {
   description = "Database name for Dagster"

--- a/tf/modules/dagster/variables.tf
+++ b/tf/modules/dagster/variables.tf
@@ -74,7 +74,7 @@ variable "deployment_mode" {
 
 # Per-container resource limits for the consolidated deployment.
 # The instance total is the SUM across the three containers and must resolve to a
-# supported Cloud Run CPU size. Defaults sum to 1 vCPU / 2Gi.
+# supported Cloud Run CPU size. Defaults sum to 1 vCPU / 2.5Gi.
 #
 # Cost break-even (us-central1, always-allocated, no CUD): a consolidated instance
 # runs ~$55/mo at the 1 vCPU default but ~$105-110/mo at 2 vCPU / 2.5Gi — the
@@ -94,7 +94,7 @@ variable "consolidated_resources" {
   default = {
     webserver   = { cpu = "500m", memory = "512Mi" }
     code_server = { cpu = "250m", memory = "1Gi" }
-    daemon      = { cpu = "250m", memory = "512Mi" }
+    daemon      = { cpu = "250m", memory = "1Gi" } # matches split's daemon memory; 512Mi risks OOM loops
   }
 }
 

--- a/tf/modules/dagster/webserver.tf
+++ b/tf/modules/dagster/webserver.tf
@@ -1,6 +1,9 @@
 # Cloud Run service for Dagster webserver (UI)
 
 resource "google_cloud_run_v2_service" "webserver" {
+  # Only created in split mode; consolidated mode uses google_cloud_run_v2_service.consolidated
+  count = local.is_split ? 1 : 0
+
   # Use beta provider for IAP support
   provider = google-beta
 
@@ -129,7 +132,7 @@ resource "google_cloud_run_v2_service_iam_member" "webserver_public_invoker" {
   count = var.iap_allowed_domain == null ? 1 : 0
 
   provider = google-beta
-  name     = google_cloud_run_v2_service.webserver.name
+  name     = local.webserver_service_name
   location = var.region
   project  = var.project_id
   role     = "roles/run.invoker"
@@ -141,7 +144,7 @@ resource "google_cloud_run_v2_service_iam_member" "webserver_iap_invoker" {
   count = var.iap_allowed_domain != null ? 1 : 0
 
   provider = google-beta
-  name     = google_cloud_run_v2_service.webserver.name
+  name     = local.webserver_service_name
   location = var.region
   project  = var.project_id
   role     = "roles/run.invoker"
@@ -155,7 +158,7 @@ resource "google_iap_web_cloud_run_service_iam_member" "webserver_domain_access"
   provider               = google-beta
   project                = var.project_number # Must use project number, not ID
   location               = var.region
-  cloud_run_service_name = google_cloud_run_v2_service.webserver.name
+  cloud_run_service_name = local.webserver_service_name
   role                   = "roles/iap.httpsResourceAccessor"
   member                 = "domain:${var.iap_allowed_domain}"
 }
@@ -173,6 +176,6 @@ resource "google_cloud_run_domain_mapping" "webserver" {
   }
 
   spec {
-    route_name = google_cloud_run_v2_service.webserver.name
+    route_name = local.webserver_service_name
   }
 }

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -126,6 +126,18 @@ variable "dagster_code_server_image" {
   default     = "us-central1-docker.pkg.dev/gtfs-archiver/ghcr-remote/jarvusinnovations/gtfs-realtime-archiver/dagster-code-server:latest"
 }
 
+# Dagster deployment topology
+variable "dagster_deployment_mode" {
+  description = "Dagster topology: \"split\" (default, each component its own resource) or \"consolidated\" (webserver + daemon + code server in one always-on instance; lowest cost floor, single code location)."
+  type        = string
+  default     = "split"
+
+  validation {
+    condition     = contains(["split", "consolidated"], var.dagster_deployment_mode)
+    error_message = "dagster_deployment_mode must be either \"split\" or \"consolidated\"."
+  }
+}
+
 # Dagster IAP configuration
 variable "dagster_iap_allowed_domain" {
   description = "Google Workspace domain allowed to access Dagster via IAP (e.g., 'example.com'). Set to null to disable IAP."


### PR DESCRIPTION
Add a `deployment_mode` toggle to the Dagster module to support a minimal
single-instance topology alongside the existing split topology.

- "split" (default, unchanged): webserver Service + daemon Worker Pool +
  code-server Service, each its own Cloud Run resource.
- "consolidated": webserver (ingress) + daemon + code server as three
  containers in ONE always-on Cloud Run Service (consolidated.tf), for a
  single code location. Collapses the daemon + daemon-kept-warm code server
  into one always-on footprint for the lowest cost floor.

Consolidated service constraints: max_instance_count = 1 (daemon must be a
singleton), cpu_idle = false / instance-based billing (sidecars would
otherwise be starved between UI requests), and code server reached over
localhost (no internal code-server Service). Run workers are unchanged
(per-run Cloud Run Jobs).

Split resources are gated with count/for_each on the mode; IAP, public
invoker, and domain mapping now target a shared local that resolves to
whichever Service carries the webserver ingress. Database, buckets,
secrets, run-worker job, and service accounts are shared across both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018Px9ijS49rEHfnDwhbEjxo