### PR TITLE
Release: v0.9.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -370,6 +370,25 @@ The module supports two topologies, selected via `dagster_deployment_mode`
   the active one; the database, buckets, secrets, run-worker job, and service
   accounts are shared across both.
 
+  **Cost break-even**: at the default sizing (containers summing to 1 vCPU / 2Gi)
+  the consolidated instance runs ~$55/mo — vs ~$100/mo idle for the split topology
+  (always-on daemon + daemon-kept-warm code server). Sized up to 2 vCPU / 2.5Gi it
+  is ~$105–110/mo, a wash against split. Consolidation saves money only at roughly
+  ≤1.5 vCPU total; see the note on `consolidated_resources` in
+  `tf/modules/dagster/variables.tf`.
+
+**Terraform image variables move with releases — never apply with stale ones**:
+
+The release workflow (`.github/workflows/deploy.yaml`) deploys by running
+`tofu apply` with `-var` image values derived from the release tag. Terraform
+*is* the image mover, so the image fields deliberately have **no**
+`lifecycle ignore_changes` (that would silently break CI deploys). The corollary:
+a local `tofu plan`/`apply` that doesn't pass the currently-deployed image
+versions will show (and would roll back!) image "downgrades" to whatever stale
+values are in tfvars/defaults. Before any local apply, derive the image vars from
+the latest release tag (as deploy.yaml does), pass `-target` for the resources
+you're changing, or confirm the plan shows no image changes.
+
 ## Testing Container Builds
 
 **When to test locally**:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -70,9 +70,10 @@ gtfs-realtime-archiver/
 │   ├── dagster.tf          # Dagster module instantiation
 │   ├── modules/dagster/    # Dagster deployment module
 │   │   ├── main.tf         # Module locals and config
-│   │   ├── webserver.tf    # Dagster UI (Cloud Run Service)
-│   │   ├── daemon.tf       # Dagster daemon (Worker Pool)
-│   │   ├── code_server.tf  # gRPC code servers
+│   │   ├── webserver.tf    # Dagster UI (Cloud Run Service, split mode)
+│   │   ├── daemon.tf       # Dagster daemon (Worker Pool, split mode)
+│   │   ├── code_server.tf  # gRPC code servers (split mode)
+│   │   ├── consolidated.tf # Single-instance web+daemon+code (consolidated mode)
 │   │   ├── run_worker.tf   # Cloud Run Jobs for runs
 │   │   ├── iam.tf          # Service accounts and permissions
 │   │   ├── secrets.tf      # DB password secret
@@ -338,6 +339,36 @@ Each location gets:
 - Dedicated code server (gRPC)
 - Dedicated run worker job
 - Dedicated service account with specific IAM permissions
+
+**Deployment Topologies** (`deployment_mode` variable):
+
+The module supports two topologies, selected via `dagster_deployment_mode`
+(root) / `deployment_mode` (module). Default is `split`.
+
+- **`split`** (default): webserver, daemon, and code server each run as their
+  own Cloud Run resource (Service / Worker Pool / Service). The webserver scales
+  0→N and the code server is isolated so code reloads don't affect the host
+  processes. Use when you need horizontal UI scaling or multiple code locations.
+
+- **`consolidated`**: webserver (ingress) + daemon + code server run as three
+  containers in **one always-on Cloud Run Service instance** (`consolidated.tf`),
+  for a single code location. Lowest cost floor — collapses what is otherwise two
+  always-on footprints (daemon + daemon-kept-warm code server) into one. Run
+  workers are unchanged (still per-run Cloud Run Jobs).
+
+  Constraints baked into the consolidated service:
+  - `max_instance_count = 1` — the daemon must be a singleton (a second instance
+    would double-fire schedules/sensors).
+  - `cpu_idle = false` (instance-based billing) — in a request-billed Service,
+    sidecars only get CPU while the ingress handles a request, which starves the
+    always-on daemon. Always-allocated CPU is required.
+  - The code server is reached over `localhost` (`CODE_SERVER_HOST_<LOC>=localhost`,
+    port from `deploy/workspace.yaml`); no internal code-server Service is created.
+
+  Flip topologies with `dagster_deployment_mode = "consolidated"` in tfvars and
+  `tofu apply`. Switching destroys the resources of the other topology and creates
+  the active one; the database, buckets, secrets, run-worker job, and service
+  accounts are shared across both.
 
 ## Testing Container Builds
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -358,7 +358,10 @@ The module supports two topologies, selected via `dagster_deployment_mode`
 
   Constraints baked into the consolidated service:
   - `max_instance_count = 1` — the daemon must be a singleton (a second instance
-    would double-fire schedules/sensors).
+    would double-fire schedules/sensors). Caveat: unlike the split Worker Pool's
+    MANUAL scaling, a Service revision rollout can briefly run old + new instances
+    concurrently, so the daemon may transiently double-fire during deploys —
+    acceptable for idempotent schedules, worth knowing about.
   - `cpu_idle = false` (instance-based billing) — in a request-billed Service,
     sidecars only get CPU while the ingress handles a request, which starves the
     always-on daemon. Always-allocated CPU is required.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -67,15 +67,17 @@ gtfs-realtime-archiver/
 │   ├── storage.tf          # GCS bucket with lifecycle
 │   ├── iam.tf              # Service account and permissions
 │   ├── cloudsql.tf         # Cloud SQL PostgreSQL instance
-│   ├── dagster.tf          # Dagster module instantiation
-│   ├── modules/dagster/    # Dagster deployment module
+│   ├── dagster.tf          # Dagster module instantiation (project wiring via extra_env/grants)
+│   ├── dagster_moved.tf    # State moves from the module's generalization (delete after applied)
+│   ├── modules/dagster/    # Dagster deployment module (generic — being extracted to a registry module)
 │   │   ├── main.tf         # Module locals and config
 │   │   ├── webserver.tf    # Dagster UI (Cloud Run Service, split mode)
 │   │   ├── daemon.tf       # Dagster daemon (Worker Pool, split mode)
 │   │   ├── code_server.tf  # gRPC code servers (split mode)
 │   │   ├── consolidated.tf # Single-instance web+daemon+code (consolidated mode)
 │   │   ├── run_worker.tf   # Cloud Run Jobs for runs
-│   │   ├── iam.tf          # Service accounts and permissions
+│   │   ├── iam.tf          # Service accounts, permissions + generic bucket/secret grants
+│   │   ├── hmac.tf         # Optional per-run-worker GCS HMAC keys (dbt-duckdb httpfs)
 │   │   ├── secrets.tf      # DB password secret
 │   │   ├── database.tf     # Database and user creation
 │   │   └── storage.tf      # Logs bucket

--- a/.claude/commands/add-agency.md
+++ b/.claude/commands/add-agency.md
@@ -8,7 +8,13 @@ Add a new transit agency to the GTFS-RT Archiver by searching for feed sources, 
 
 ### Step 1: Search Local Mobility Database Catalogs
 
-Search the local copy of the Mobility Database for GTFS-RT feeds:
+Search the local copy of the Mobility Database for GTFS-RT feeds.
+
+`.scratch/` is unversioned — if `.scratch/mobility-database-catalogs` doesn't exist yet, clone it first:
+
+```bash
+git clone --depth 1 https://github.com/MobilityData/mobility-database-catalogs .scratch/mobility-database-catalogs
+```
 
 ```bash
 # Search for agency by name (case-insensitive)
@@ -188,7 +194,7 @@ grep -E "^  - id:" agencies.yaml
 ### Common Feed Providers
 
 | Provider | Auth Type | Header/Param |
-|----------|-----------|--------------|
+| ---------- | ----------- | -------------- |
 | Azure API Management | header | `Ocp-Apim-Subscription-Key` |
 | 511.org | query | `api_key` |
 | Swiftly | header | `Authorization: Bearer {token}` |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -962,6 +962,14 @@ Note that releases deploy by running `tofu apply` with image `-var`s derived fro
 the release tag (see `.github/workflows/deploy.yaml`) — local applies must supply
 current image versions or they will roll deployed images back.
 
+The `tf/modules/dagster/` module is deliberately generic (no GTFS-specific
+variables): this project's buckets, secrets, and env are wired through the
+module's `extra_env`, `bucket_grants`, `secret_grants`, and `run_worker_secret_env`
+maps in `tf/dagster.tf`. The module also supports private-ingress + reverse-proxy
+exposure (`public_ingress`, `path_prefix`) and optional per-run-worker GCS HMAC
+keys (`enable_dbt_hmac_keys`) used by sibling deployments; it is being extracted
+to a standalone Terraform Registry module.
+
 ---
 
 ## Appendix A: Dependency Justification

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -952,12 +952,22 @@ tofu apply -var-file=prod.tfvars
 tofu destroy -var-file=prod.tfvars
 ```
 
+The Dagster deployment supports two topologies via `dagster_deployment_mode`:
+`split` (default; each component its own Cloud Run resource) and `consolidated`
+(webserver + daemon + code server as three containers in one always-on instance —
+lowest cost floor, single code location only). Constraints and cost break-even are
+documented in "Deployment Topologies" in `.claude/CLAUDE.md`.
+
+Note that releases deploy by running `tofu apply` with image `-var`s derived from
+the release tag (see `.github/workflows/deploy.yaml`) — local applies must supply
+current image versions or they will roll deployed images back.
+
 ---
 
 ## Appendix A: Dependency Justification
 
 | Dependency | Purpose | Alternatives Considered |
-|------------|---------|------------------------|
+| ------------ | --------- | ------------------------ |
 | **httpx** | Async HTTP client | aiohttp (less ergonomic), requests (sync only) |
 | **apscheduler** | In-process job scheduling | schedule (no async), celery (overkill) |
 | **pydantic** | Data validation & settings | attrs (less features), dataclasses (no validation) |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -967,7 +967,7 @@ current image versions or they will roll deployed images back.
 ## Appendix A: Dependency Justification
 
 | Dependency | Purpose | Alternatives Considered |
-| ------------ | --------- | ------------------------ |
+|------------|---------|------------------------|
 | **httpx** | Async HTTP client | aiohttp (less ergonomic), requests (sync only) |
 | **apscheduler** | In-process job scheduling | schedule (no async), celery (overkill) |
 | **pydantic** | Data validation & settings | attrs (less features), dataclasses (no validation) |

--- a/README.md
+++ b/README.md
@@ -334,6 +334,15 @@ Required for Dagster:
 - `GCS_BUCKET_RT_PROTOBUF`: Source bucket with protobuf archives
 - `GCS_BUCKET_RT_PARQUET`: Target bucket for parquet output
 
+### Deployment topology
+
+The Cloud Run deployment supports two topologies via the `dagster_deployment_mode`
+Terraform variable: `split` (default — webserver, daemon, and code server as
+separate Cloud Run resources) and `consolidated` (all three as containers in one
+always-on instance, for the lowest cost floor with a single code location). See
+"Deployment Topologies" in `.claude/CLAUDE.md` for constraints and cost
+break-even details.
+
 ## License
 
 AGPL-3.0

--- a/deploy/dagster.yaml
+++ b/deploy/dagster.yaml
@@ -17,9 +17,10 @@ run_launcher:
     region:
       env: GCP_REGION
     job_name_by_code_location:
-      # Key must match the module name Dagster uses for the code location
-      # Value is the Cloud Run job name from Terraform
-      dagster_pipeline.definitions: dagster-run-worker-gtfsrt
+      # Key must match workspace.yaml's location_name — CloudRunRunLauncher
+      # resolves the job by remote_job_origin.location_name, NOT the module
+      # name. Value is the Cloud Run job name from Terraform.
+      gtfsrt: dagster-run-worker-gtfsrt
     run_timeout: 86400
 
 # Queued run coordinator for managing concurrent runs

--- a/tf/dagster.tf
+++ b/tf/dagster.tf
@@ -16,6 +16,8 @@ module "dagster" {
   parquet_bucket_name  = google_storage_bucket.parquet.name
   agencies_secret_id   = var.agencies_secret_id
 
+  deployment_mode = var.dagster_deployment_mode
+
   webserver_image = var.dagster_webserver_image
   daemon_image    = var.dagster_daemon_image
 

--- a/tf/dagster.tf
+++ b/tf/dagster.tf
@@ -5,12 +5,27 @@ data "google_project" "current" {
   project_id = var.project_id
 }
 
+# Shared-pg switchover (2026-07): Dagster metadata now lives in the
+# multi-tenant jarvus-shared-postgres instance (tenant: dagster_gtfsrt; see
+# infra-ops projects/shared-postgres). The local dagster-postgres instance
+# (PG14, EOL pressure) is retained for rollback until the cleanup PR.
+data "google_secret_manager_secret_version" "shared_pg_password" {
+  secret = "shared-pg-dagster_gtfsrt-password"
+}
+
 module "dagster" {
   source = "./modules/dagster"
 
   project_id                = var.project_id
   region                    = var.region
-  cloud_sql_connection_name = google_sql_database_instance.dagster.connection_name
+  cloud_sql_connection_name = "jarvus-shared-postgres:us-east4:shared-pg"
+
+  # External-database mode: the shared root provisions the isolated tenant
+  # database + SQL-native user; the module only composes the URL.
+  manage_database = false
+  db_name         = "dagster_gtfsrt"
+  db_user         = "dagster_gtfsrt_app"
+  db_password     = data.google_secret_manager_secret_version.shared_pg_password.secret_data
 
   # Consumer-domain wiring: the module is generic, this project's buckets and
   # secrets are expressed as env + grants (see modules/dagster/variables.tf).
@@ -67,7 +82,4 @@ module "dagster" {
     project = "gtfs-rt-archiver"
   }
 
-  depends_on = [
-    google_sql_database_instance.dagster
-  ]
 }

--- a/tf/dagster.tf
+++ b/tf/dagster.tf
@@ -12,9 +12,36 @@ module "dagster" {
   region                    = var.region
   cloud_sql_connection_name = google_sql_database_instance.dagster.connection_name
 
-  protobuf_bucket_name = google_storage_bucket.protobuf.name
-  parquet_bucket_name  = google_storage_bucket.parquet.name
-  agencies_secret_id   = var.agencies_secret_id
+  # Consumer-domain wiring: the module is generic, this project's buckets and
+  # secrets are expressed as env + grants (see modules/dagster/variables.tf).
+  extra_env = {
+    GCS_BUCKET_RT_PROTOBUF = google_storage_bucket.protobuf.name
+    GCS_BUCKET_RT_PARQUET  = google_storage_bucket.parquet.name
+    AGENCIES_SECRET_ID     = var.agencies_secret_id
+  }
+
+  bucket_grants = {
+    # Sensors (primary SA) discover feeds by listing; run workers read source
+    # protobufs for compaction.
+    rt-protobuf = {
+      bucket          = google_storage_bucket.protobuf.name
+      dagster_role    = "roles/storage.objectViewer"
+      run_worker_role = "roles/storage.objectViewer"
+    }
+    # Run workers write compacted parquet output.
+    rt-parquet = {
+      bucket          = google_storage_bucket.parquet.name
+      run_worker_role = "roles/storage.objectUser"
+    }
+  }
+
+  secret_grants = {
+    # agencies.yaml config, read by the feeds_metadata asset in run workers.
+    agencies = {
+      secret_id  = var.agencies_secret_id
+      run_worker = true
+    }
+  }
 
   deployment_mode = var.dagster_deployment_mode
 

--- a/tf/dagster_moved.tf
+++ b/tf/dagster_moved.tf
@@ -1,0 +1,30 @@
+# State moves for the dagster module's generalization of project-specific
+# variables into generic bucket_grants / secret_grants maps.
+#
+# The module renamed its consumer-specific IAM resources to generic map-keyed
+# ones; these moves keep the live bindings in place instead of destroy/create
+# (which would open a brief permission gap for running sensors/jobs).
+#
+# Safe to delete once applied (moves are recorded in state) — and MUST be
+# deleted when the module source switches to the Terraform Registry, since
+# moved blocks may not reference resources across module packages.
+
+moved {
+  from = module.dagster.google_storage_bucket_iam_member.dagster_protobuf_reader
+  to   = module.dagster.google_storage_bucket_iam_member.dagster_bucket["rt-protobuf"]
+}
+
+moved {
+  from = module.dagster.google_storage_bucket_iam_member.run_worker_protobuf_reader["gtfsrt"]
+  to   = module.dagster.google_storage_bucket_iam_member.run_worker_bucket["rt-protobuf:gtfsrt"]
+}
+
+moved {
+  from = module.dagster.google_storage_bucket_iam_member.run_worker_parquet_writer["gtfsrt"]
+  to   = module.dagster.google_storage_bucket_iam_member.run_worker_bucket["rt-parquet:gtfsrt"]
+}
+
+moved {
+  from = module.dagster.google_secret_manager_secret_iam_member.run_worker_agencies_config["gtfsrt"]
+  to   = module.dagster.google_secret_manager_secret_iam_member.run_worker_secret["agencies:gtfsrt"]
+}

--- a/tf/modules/dagster/code_server.tf
+++ b/tf/modules/dagster/code_server.tf
@@ -23,9 +23,10 @@ resource "google_cloud_run_v2_service" "code_server" {
     # No VPC connector - use Cloud SQL socket mount
     # Cloud Run connects to Cloud SQL via built-in Cloud SQL Auth Proxy
 
-    # Dagster code server can only have 1 instance
+    # Dagster code server can only have 1 instance. Note the always-on daemon
+    # keeps it warm in practice regardless of the minimum (sensor gRPC polls).
     scaling {
-      min_instance_count = 0
+      min_instance_count = var.code_server_min_instances
       max_instance_count = 1
     }
 

--- a/tf/modules/dagster/code_server.tf
+++ b/tf/modules/dagster/code_server.tf
@@ -2,7 +2,8 @@
 # One service per code location
 
 resource "google_cloud_run_v2_service" "code_server" {
-  for_each = var.code_locations
+  # Only created in split mode; consolidated mode runs the code server as a sidecar
+  for_each = local.is_split ? var.code_locations : {}
 
   name     = "dagster-code-server-${each.key}"
   location = var.region

--- a/tf/modules/dagster/consolidated.tf
+++ b/tf/modules/dagster/consolidated.tf
@@ -30,9 +30,9 @@ resource "google_cloud_run_v2_service" "consolidated" {
   location = var.region
   project  = var.project_id
 
-  # Enable IAP (Preview feature) - requires BETA launch stage
-  launch_stage = var.iap_allowed_domain != null ? "BETA" : null
-  iap_enabled  = var.iap_allowed_domain != null
+  # Cloud Run IAP is GA (forcing BETA would show as a perpetual plan diff on
+  # auto-promoted services — see webserver.tf).
+  iap_enabled = var.iap_allowed_domain != null
 
   # Allow external access to the UI
   ingress = "INGRESS_TRAFFIC_ALL"
@@ -132,7 +132,11 @@ resource "google_cloud_run_v2_service" "consolidated" {
       image      = var.webserver_image
       depends_on = ["code-server"]
 
-      command = ["dagster-webserver", "--host", "0.0.0.0", "--port", "3000"]
+      # --path-prefix mirrors webserver.tf (reverse-proxy subpath support)
+      command = concat(
+        ["dagster-webserver", "--host", "0.0.0.0", "--port", "3000"],
+        var.path_prefix != "" ? ["--path-prefix", var.path_prefix] : []
+      )
 
       volume_mounts {
         name       = "cloudsql"
@@ -180,7 +184,7 @@ resource "google_cloud_run_v2_service" "consolidated" {
 
       startup_probe {
         http_get {
-          path = "/server_info"
+          path = "${var.path_prefix}/server_info"
           port = 3000
         }
         initial_delay_seconds = 5
@@ -191,7 +195,7 @@ resource "google_cloud_run_v2_service" "consolidated" {
 
       liveness_probe {
         http_get {
-          path = "/server_info"
+          path = "${var.path_prefix}/server_info"
           port = 3000
         }
         period_seconds    = 30

--- a/tf/modules/dagster/consolidated.tf
+++ b/tf/modules/dagster/consolidated.tf
@@ -6,7 +6,7 @@
 # Created only when var.deployment_mode == "consolidated". In that mode the split
 # webserver Service, daemon Worker Pool, and code-server Service are not created.
 #
-# Key constraints (see DESIGN.md "Deployment topologies"):
+# Key constraints (see CLAUDE.md "Deployment Topologies"):
 #   - max_instance_count = 1: the daemon must be a singleton. A second instance
 #     would double-fire schedules and double-evaluate sensors.
 #   - cpu_idle = false (instance-based billing): in a request-billed Service,
@@ -107,7 +107,9 @@ resource "google_cloud_run_v2_service" "consolidated" {
         cpu_idle = false # instance-based billing (always-allocated CPU)
       }
 
-      # gRPC startup probe - gates the webserver/daemon container start order
+      # gRPC startup probe - gates the webserver/daemon container start order.
+      # Cloud Run requires timeout_seconds <= period_seconds (matches the split
+      # code_server.tf probe); threshold 4 keeps the ~2 minute startup budget.
       startup_probe {
         grpc {
           port    = local.consolidated_location.port
@@ -115,8 +117,8 @@ resource "google_cloud_run_v2_service" "consolidated" {
         }
         initial_delay_seconds = 0
         timeout_seconds       = 30
-        period_seconds        = 10
-        failure_threshold     = 12
+        period_seconds        = 30
+        failure_threshold     = 4
       }
     }
 
@@ -246,4 +248,14 @@ resource "google_cloud_run_v2_service" "consolidated" {
   depends_on = [
     google_secret_manager_secret_iam_member.dagster_postgres_url
   ]
+
+  lifecycle {
+    # Consolidated mode co-locates exactly one code server. With more locations,
+    # only the first would be wired in while run_worker.tf still creates Jobs for
+    # all of them — fail fast instead of half-deploying.
+    precondition {
+      condition     = length(var.code_locations) == 1
+      error_message = "deployment_mode = \"consolidated\" supports exactly one code location; var.code_locations has ${length(var.code_locations)} entries. Use deployment_mode = \"split\" for multiple code locations."
+    }
+  }
 }

--- a/tf/modules/dagster/consolidated.tf
+++ b/tf/modules/dagster/consolidated.tf
@@ -1,0 +1,249 @@
+# Consolidated single-instance Dagster deployment (minimal cost floor / "rung 1").
+#
+# Runs the webserver (ingress), daemon, and code server as three containers in ONE
+# always-on Cloud Run Service instance, for a single code location.
+#
+# Created only when var.deployment_mode == "consolidated". In that mode the split
+# webserver Service, daemon Worker Pool, and code-server Service are not created.
+#
+# Key constraints (see DESIGN.md "Deployment topologies"):
+#   - max_instance_count = 1: the daemon must be a singleton. A second instance
+#     would double-fire schedules and double-evaluate sensors.
+#   - cpu_idle = false (instance-based billing): in a request-billed Service,
+#     sidecars only receive CPU while the ingress container is handling a request,
+#     which would starve the always-on daemon between UI requests. Always-allocated
+#     CPU is required for the daemon to tick reliably.
+#   - Inter-container traffic is over localhost. The code server listens on its
+#     configured port (3030, matching deploy/workspace.yaml); the webserver and
+#     daemon reach it at CODE_SERVER_HOST_<LOC> = "localhost". No separate internal
+#     code-server Service is created, and no gRPC traffic leaves the instance.
+#   - Run workers are unaffected: they are still launched per-run as Cloud Run Jobs
+#     by the CloudRunRunLauncher (see run_worker.tf).
+
+resource "google_cloud_run_v2_service" "consolidated" {
+  count = local.is_consolidated ? 1 : 0
+
+  # Use beta provider for IAP support (parity with the split webserver)
+  provider = google-beta
+
+  name     = "dagster"
+  location = var.region
+  project  = var.project_id
+
+  # Enable IAP (Preview feature) - requires BETA launch stage
+  launch_stage = var.iap_allowed_domain != null ? "BETA" : null
+  iap_enabled  = var.iap_allowed_domain != null
+
+  # Allow external access to the UI
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  deletion_protection = false
+
+  labels = local.common_labels
+
+  template {
+    service_account = google_service_account.dagster.email
+
+    # Single always-on instance: the daemon must be unique.
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 1
+    }
+
+    # Cloud SQL volume mount for Unix socket connection (shared by all containers)
+    volumes {
+      name = "cloudsql"
+      cloud_sql_instance {
+        instances = [var.cloud_sql_connection_name]
+      }
+    }
+
+    # --- Code server (gRPC; started first via container dependency) ---
+    containers {
+      name  = "code-server"
+      image = local.consolidated_location.image
+
+      command = [
+        "dagster", "api", "grpc",
+        "--host", "0.0.0.0",
+        "--port", tostring(local.consolidated_location.port),
+        "--module-name", local.consolidated_location.module_name,
+      ]
+
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
+
+      dynamic "env" {
+        for_each = local.common_env
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      env {
+        name = "DAGSTER_POSTGRES_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.postgres_url.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      # Current image so Dagster tags runs / run workers with the right image
+      env {
+        name  = "DAGSTER_CURRENT_IMAGE"
+        value = local.consolidated_location.image
+      }
+
+      resources {
+        limits = {
+          cpu    = var.consolidated_resources.code_server.cpu
+          memory = var.consolidated_resources.code_server.memory
+        }
+        cpu_idle = false # instance-based billing (always-allocated CPU)
+      }
+
+      # gRPC startup probe - gates the webserver/daemon container start order
+      startup_probe {
+        grpc {
+          port    = local.consolidated_location.port
+          service = "DagsterApi"
+        }
+        initial_delay_seconds = 0
+        timeout_seconds       = 30
+        period_seconds        = 10
+        failure_threshold     = 12
+      }
+    }
+
+    # --- Webserver (ingress container, HTTP 3000) ---
+    containers {
+      name       = "webserver"
+      image      = var.webserver_image
+      depends_on = ["code-server"]
+
+      command = ["dagster-webserver", "--host", "0.0.0.0", "--port", "3000"]
+
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
+
+      dynamic "env" {
+        for_each = local.common_env
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      # Code server is co-located: reach it over localhost.
+      # deploy/workspace.yaml pins the port (3030), so only the host is supplied.
+      env {
+        name  = "CODE_SERVER_HOST_${upper(local.consolidated_location_key)}"
+        value = "localhost"
+      }
+
+      env {
+        name = "DAGSTER_POSTGRES_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.postgres_url.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      ports {
+        name           = "http1"
+        container_port = 3000
+      }
+
+      resources {
+        limits = {
+          cpu    = var.consolidated_resources.webserver.cpu
+          memory = var.consolidated_resources.webserver.memory
+        }
+        cpu_idle          = false
+        startup_cpu_boost = true
+      }
+
+      startup_probe {
+        http_get {
+          path = "/server_info"
+          port = 3000
+        }
+        initial_delay_seconds = 5
+        timeout_seconds       = 5
+        period_seconds        = 10
+        failure_threshold     = 12 # 2 minutes startup time
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/server_info"
+          port = 3000
+        }
+        period_seconds    = 30
+        timeout_seconds   = 5
+        failure_threshold = 3
+      }
+    }
+
+    # --- Daemon (sidecar; scheduler, sensors, run queue, run monitoring) ---
+    containers {
+      name       = "daemon"
+      image      = var.daemon_image
+      depends_on = ["code-server"]
+
+      command = ["dagster-daemon", "run"]
+
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
+
+      dynamic "env" {
+        for_each = local.common_env
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      env {
+        name  = "CODE_SERVER_HOST_${upper(local.consolidated_location_key)}"
+        value = "localhost"
+      }
+
+      env {
+        name = "DAGSTER_POSTGRES_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.postgres_url.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      resources {
+        limits = {
+          cpu    = var.consolidated_resources.daemon.cpu
+          memory = var.consolidated_resources.daemon.memory
+        }
+        cpu_idle = false # always-allocated so the daemon ticks without UI traffic
+      }
+
+      # No liveness probe - dagster-daemon exposes no HTTP/TCP endpoint.
+      # Cloud Run's automatic restart handles daemon crashes.
+    }
+  }
+
+  depends_on = [
+    google_secret_manager_secret_iam_member.dagster_postgres_url
+  ]
+}

--- a/tf/modules/dagster/consolidated.tf
+++ b/tf/modules/dagster/consolidated.tf
@@ -105,6 +105,10 @@ resource "google_cloud_run_v2_service" "consolidated" {
           memory = var.consolidated_resources.code_server.memory
         }
         cpu_idle = false # instance-based billing (always-allocated CPU)
+        # Boost bills only during startup; without it a fractional-CPU code server
+        # importing heavy definitions can blow the 120s startup-probe budget and
+        # wedge the whole instance (webserver/daemon depends_on this container).
+        startup_cpu_boost = true
       }
 
       # gRPC startup probe - gates the webserver/daemon container start order.
@@ -237,7 +241,8 @@ resource "google_cloud_run_v2_service" "consolidated" {
           cpu    = var.consolidated_resources.daemon.cpu
           memory = var.consolidated_resources.daemon.memory
         }
-        cpu_idle = false # always-allocated so the daemon ticks without UI traffic
+        cpu_idle          = false # always-allocated so the daemon ticks without UI traffic
+        startup_cpu_boost = true  # boost bills only during startup
       }
 
       # No liveness probe - dagster-daemon exposes no HTTP/TCP endpoint.

--- a/tf/modules/dagster/daemon.tf
+++ b/tf/modules/dagster/daemon.tf
@@ -9,8 +9,10 @@ resource "google_cloud_run_v2_worker_pool" "daemon" {
   location = var.region
   project  = var.project_id
 
-  # Worker Pool is in BETA
-  launch_stage = "BETA"
+  # google_cloud_run_v2_worker_pool graduated to GA in 2025; Google
+  # auto-promoted deployed pools' launch_stage. Match that here so
+  # tofu doesn't try to downgrade it back to BETA.
+  launch_stage = "GA"
 
   # Prevent accidental deletion
   deletion_protection = false

--- a/tf/modules/dagster/daemon.tf
+++ b/tf/modules/dagster/daemon.tf
@@ -2,6 +2,9 @@
 # Worker Pools are designed for continuous background work without HTTP endpoints
 
 resource "google_cloud_run_v2_worker_pool" "daemon" {
+  # Only created in split mode; consolidated mode runs the daemon as a sidecar
+  count = local.is_split ? 1 : 0
+
   name     = "dagster-daemon"
   location = var.region
   project  = var.project_id

--- a/tf/modules/dagster/database.tf
+++ b/tf/modules/dagster/database.tf
@@ -1,5 +1,7 @@
 # Create database in the provided Cloud SQL instance
 resource "google_sql_database" "dagster" {
+  count = var.manage_database ? 1 : 0
+
   name     = var.db_name
   instance = local.cloud_sql_instance_name
   project  = var.project_id
@@ -7,6 +9,8 @@ resource "google_sql_database" "dagster" {
 
 # Create database user
 resource "google_sql_user" "dagster" {
+  count = var.manage_database ? 1 : 0
+
   name     = var.db_user
   instance = local.cloud_sql_instance_name
   password = random_password.db_password.result

--- a/tf/modules/dagster/hmac.tf
+++ b/tf/modules/dagster/hmac.tf
@@ -1,0 +1,78 @@
+# Optional GCS HMAC credentials per run-worker SA (var.enable_dbt_hmac_keys).
+#
+# Why: pipelines that use DuckDB/dbt-duckdb with `materialized = 'external'`
+# write models directly to gs://... locations so separate run-worker containers
+# can resolve `ref()` across runs. Those writes go through DuckDB's httpfs
+# extension, which speaks S3-compatible auth — an HMAC key provides that for
+# GCS.
+#
+# Lifecycle is managed by Terraform: rotation is
+# `tofu taint 'module.<name>.google_storage_hmac_key.dbt_gcs["<location>"]'`
+# + apply. Values flow into Secret Manager and into the run-worker job template
+# via env var refs (see run_worker.tf; names from var.hmac_env_names). HMAC
+# values exist in Terraform state — same trust boundary as the postgres URL and
+# other auto-generated secrets.
+#
+# One key per code location, mirroring the per-code-location run-worker SA
+# pattern; future code locations get their own key automatically.
+
+resource "google_storage_hmac_key" "dbt_gcs" {
+  for_each = var.enable_dbt_hmac_keys ? google_service_account.run_worker : {}
+
+  service_account_email = each.value.email
+  project               = var.project_id
+}
+
+resource "google_secret_manager_secret" "dbt_gcs_hmac_key_id" {
+  for_each  = google_storage_hmac_key.dbt_gcs
+  secret_id = "dbt-gcs-hmac-key-id-${each.key}"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret" "dbt_gcs_hmac_secret" {
+  for_each  = google_storage_hmac_key.dbt_gcs
+  secret_id = "dbt-gcs-hmac-secret-${each.key}"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+}
+
+# No ignore_changes — when the HMAC key is rotated (tofu taint + apply),
+# a new secret version is written and Cloud Run picks it up on next job
+# launch via `version = "latest"`.
+resource "google_secret_manager_secret_version" "dbt_gcs_hmac_key_id" {
+  for_each    = google_storage_hmac_key.dbt_gcs
+  secret      = google_secret_manager_secret.dbt_gcs_hmac_key_id[each.key].id
+  secret_data = each.value.access_id
+}
+
+resource "google_secret_manager_secret_version" "dbt_gcs_hmac_secret" {
+  for_each    = google_storage_hmac_key.dbt_gcs
+  secret      = google_secret_manager_secret.dbt_gcs_hmac_secret[each.key].id
+  secret_data = each.value.secret
+}
+
+# Each run-worker SA can read its own HMAC credentials at job start.
+resource "google_secret_manager_secret_iam_member" "run_worker_hmac_key_id" {
+  for_each = google_storage_hmac_key.dbt_gcs
+
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.dbt_gcs_hmac_key_id[each.key].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.run_worker[each.key].email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "run_worker_hmac_secret" {
+  for_each = google_storage_hmac_key.dbt_gcs
+
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.dbt_gcs_hmac_secret[each.key].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.run_worker[each.key].email}"
+}

--- a/tf/modules/dagster/iam.tf
+++ b/tf/modules/dagster/iam.tf
@@ -82,29 +82,32 @@ resource "google_storage_bucket_iam_member" "run_worker_logs_reader" {
   member = "serviceAccount:${each.value.email}"
 }
 
-# Protobuf bucket read access for primary SA (sensors discover feeds by listing objects)
-resource "google_storage_bucket_iam_member" "dagster_protobuf_reader" {
-  bucket = var.protobuf_bucket_name
-  role   = "roles/storage.objectViewer"
+# Consumer-declared bucket grants (var.bucket_grants).
+# Keys are the consumer's stable labels; run-worker grants are keyed
+# "<grant-label>:<code-location>" so both dimensions stay addressable.
+resource "google_storage_bucket_iam_member" "dagster_bucket" {
+  for_each = { for k, g in var.bucket_grants : k => g if g.dagster_role != null }
+
+  bucket = each.value.bucket
+  role   = each.value.dagster_role
   member = "serviceAccount:${google_service_account.dagster.email}"
 }
 
-# Protobuf bucket read access for run workers (read source data for compaction)
-resource "google_storage_bucket_iam_member" "run_worker_protobuf_reader" {
-  for_each = google_service_account.run_worker
+resource "google_storage_bucket_iam_member" "run_worker_bucket" {
+  for_each = {
+    for pair in setproduct(
+      [for k, g in var.bucket_grants : k if g.run_worker_role != null],
+      keys(var.code_locations)
+      ) : "${pair[0]}:${pair[1]}" => {
+      bucket   = var.bucket_grants[pair[0]].bucket
+      role     = var.bucket_grants[pair[0]].run_worker_role
+      location = pair[1]
+    }
+  }
 
-  bucket = var.protobuf_bucket_name
-  role   = "roles/storage.objectViewer"
-  member = "serviceAccount:${each.value.email}"
-}
-
-# Parquet bucket write access for run workers (write compacted output)
-resource "google_storage_bucket_iam_member" "run_worker_parquet_writer" {
-  for_each = google_service_account.run_worker
-
-  bucket = var.parquet_bucket_name
-  role   = "roles/storage.objectUser"
-  member = "serviceAccount:${each.value.email}"
+  bucket = each.value.bucket
+  role   = each.value.role
+  member = "serviceAccount:${google_service_account.run_worker[each.value.location].email}"
 }
 
 # Cloud SQL client role for service accounts (required for socket connections)
@@ -122,12 +125,29 @@ resource "google_project_iam_member" "run_worker_cloudsql_client" {
   member  = "serviceAccount:${each.value.email}"
 }
 
-# Secret Manager access for run workers (agencies config for feeds_metadata asset)
-resource "google_secret_manager_secret_iam_member" "run_worker_agencies_config" {
-  for_each = google_service_account.run_worker
+# Consumer-declared Secret Manager grants (var.secret_grants).
+resource "google_secret_manager_secret_iam_member" "dagster_secret" {
+  for_each = { for k, g in var.secret_grants : k => g if g.dagster }
 
-  secret_id = var.agencies_secret_id
+  secret_id = each.value.secret_id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${each.value.email}"
+  member    = "serviceAccount:${google_service_account.dagster.email}"
+  project   = var.project_id
+}
+
+resource "google_secret_manager_secret_iam_member" "run_worker_secret" {
+  for_each = {
+    for pair in setproduct(
+      [for k, g in var.secret_grants : k if g.run_worker],
+      keys(var.code_locations)
+      ) : "${pair[0]}:${pair[1]}" => {
+      secret_id = var.secret_grants[pair[0]].secret_id
+      location  = pair[1]
+    }
+  }
+
+  secret_id = each.value.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.run_worker[each.value.location].email}"
   project   = var.project_id
 }

--- a/tf/modules/dagster/main.tf
+++ b/tf/modules/dagster/main.tf
@@ -12,6 +12,20 @@ locals {
     component  = "dagster"
   })
 
+  # Deployment topology toggles (see var.deployment_mode)
+  is_consolidated = var.deployment_mode == "consolidated"
+  is_split        = var.deployment_mode == "split"
+
+  # Consolidated mode co-locates a single code location. Pick the (only) entry.
+  consolidated_location_key = try(keys(var.code_locations)[0], null)
+  consolidated_location     = try(var.code_locations[local.consolidated_location_key], null)
+
+  # The Service that carries the webserver ingress, used to wire IAP, the public
+  # invoker, and the custom domain mapping in both modes. Splats + one() stay safe
+  # when the non-active resource has count = 0.
+  webserver_service_name = local.is_consolidated ? one(google_cloud_run_v2_service.consolidated[*].name) : one(google_cloud_run_v2_service.webserver[*].name)
+  webserver_service_uri  = local.is_consolidated ? one(google_cloud_run_v2_service.consolidated[*].uri) : one(google_cloud_run_v2_service.webserver[*].uri)
+
   # Use provided logs bucket or create one
   logs_bucket_name = var.logs_bucket_name != null ? var.logs_bucket_name : google_storage_bucket.logs[0].name
 

--- a/tf/modules/dagster/main.tf
+++ b/tf/modules/dagster/main.tf
@@ -36,15 +36,17 @@ locals {
   # Common environment variables for all Dagster components
   # Note: Database connection is via DAGSTER_POSTGRES_URL secret (includes socket path)
   # Note: Run worker job name is hardcoded in deploy/dagster.yaml (Permissive config doesn't resolve env vars)
-  common_env = {
-    GCP_PROJECT_ID         = var.project_id
-    GCP_REGION             = var.region
-    DAGSTER_HOME           = "/opt/dagster/dagster_home"
-    GCS_BUCKET_RT_PROTOBUF = var.protobuf_bucket_name
-    GCS_BUCKET_RT_PARQUET  = var.parquet_bucket_name
-    DAGSTER_LOGS_BUCKET    = local.logs_bucket_name
-    AGENCIES_SECRET_ID     = var.agencies_secret_id
-  }
+  # Consumer-domain variables (bucket names, secret IDs the app resolves itself)
+  # come in through var.extra_env — the module defines only Dagster-generic ones.
+  common_env = merge(
+    {
+      GCP_PROJECT_ID      = var.project_id
+      GCP_REGION          = var.region
+      DAGSTER_HOME        = "/opt/dagster/dagster_home"
+      DAGSTER_LOGS_BUCKET = local.logs_bucket_name
+    },
+    var.extra_env
+  )
 }
 
 # Get project data for default compute service account reference

--- a/tf/modules/dagster/outputs.tf
+++ b/tf/modules/dagster/outputs.tf
@@ -50,7 +50,7 @@ output "run_worker_job_names" {
 # Database outputs
 output "database_name" {
   description = "Name of the Dagster database"
-  value       = google_sql_database.dagster.name
+  value       = coalesce(one(google_sql_database.dagster[*].name), var.db_name)
 }
 
 # Logs bucket output

--- a/tf/modules/dagster/outputs.tf
+++ b/tf/modules/dagster/outputs.tf
@@ -1,12 +1,17 @@
 # Webserver outputs
+output "deployment_mode" {
+  description = "Active Dagster deployment topology (split or consolidated)"
+  value       = var.deployment_mode
+}
+
 output "webserver_url" {
   description = "URL of the Dagster webserver (Cloud Run URL)"
-  value       = google_cloud_run_v2_service.webserver.uri
+  value       = local.webserver_service_uri
 }
 
 output "webserver_service_name" {
-  description = "Name of the webserver Cloud Run service"
-  value       = google_cloud_run_v2_service.webserver.name
+  description = "Name of the Cloud Run service serving the Dagster webserver"
+  value       = local.webserver_service_name
 }
 
 output "webserver_iap_url" {

--- a/tf/modules/dagster/run_worker.tf
+++ b/tf/modules/dagster/run_worker.tf
@@ -65,6 +65,41 @@ resource "google_cloud_run_v2_job" "run_worker" {
           }
         }
 
+        # Consumer-declared secret-backed env vars (var.run_worker_secret_env).
+        # Deliberately run-worker only: code servers introspect the asset graph
+        # and shouldn't hold materialization credentials.
+        dynamic "env" {
+          for_each = var.run_worker_secret_env
+          content {
+            name = env.key
+            value_source {
+              secret_key_ref {
+                secret  = env.value
+                version = "latest"
+              }
+            }
+          }
+        }
+
+        # GCS HMAC credentials for DuckDB/dbt-duckdb httpfs writes — see hmac.tf.
+        # Env names come from var.hmac_env_names to match whatever the consumer's
+        # profiles.yml reads via env_var().
+        dynamic "env" {
+          for_each = var.enable_dbt_hmac_keys ? {
+            (var.hmac_env_names.key_id) = google_secret_manager_secret.dbt_gcs_hmac_key_id[each.key].secret_id
+            (var.hmac_env_names.secret) = google_secret_manager_secret.dbt_gcs_hmac_secret[each.key].secret_id
+          } : {}
+          content {
+            name = env.key
+            value_source {
+              secret_key_ref {
+                secret  = env.value
+                version = "latest"
+              }
+            }
+          }
+        }
+
         # Current image for Dagster to identify the code location image
         env {
           name  = "DAGSTER_CURRENT_IMAGE"
@@ -82,6 +117,9 @@ resource "google_cloud_run_v2_job" "run_worker" {
   }
 
   depends_on = [
-    google_secret_manager_secret_iam_member.run_worker_postgres_url
+    google_secret_manager_secret_iam_member.run_worker_postgres_url,
+    # Empty when enable_dbt_hmac_keys = false
+    google_secret_manager_secret_iam_member.run_worker_hmac_key_id,
+    google_secret_manager_secret_iam_member.run_worker_hmac_secret,
   ]
 }

--- a/tf/modules/dagster/secrets.tf
+++ b/tf/modules/dagster/secrets.tf
@@ -5,6 +5,10 @@ resource "random_password" "db_password" {
   override_special = "_-" # Conservative set safe for connection strings
 }
 
+locals {
+  effective_db_password = var.db_password != null ? var.db_password : random_password.db_password.result
+}
+
 # Store database password in Secret Manager
 resource "google_secret_manager_secret" "db_password" {
   secret_id = "dagster-db-password"
@@ -19,7 +23,7 @@ resource "google_secret_manager_secret" "db_password" {
 
 resource "google_secret_manager_secret_version" "db_password" {
   secret      = google_secret_manager_secret.db_password.id
-  secret_data = random_password.db_password.result
+  secret_data = local.effective_db_password
 }
 
 # Full PostgreSQL connection URL for Unix socket connections
@@ -37,5 +41,5 @@ resource "google_secret_manager_secret" "postgres_url" {
 
 resource "google_secret_manager_secret_version" "postgres_url" {
   secret      = google_secret_manager_secret.postgres_url.id
-  secret_data = "postgresql://${var.db_user}:${random_password.db_password.result}@/${var.db_name}?host=${local.db_socket_path}"
+  secret_data = "postgresql://${var.db_user}:${local.effective_db_password}@/${var.db_name}?host=${local.db_socket_path}"
 }

--- a/tf/modules/dagster/variables.tf
+++ b/tf/modules/dagster/variables.tf
@@ -74,18 +74,27 @@ variable "deployment_mode" {
 
 # Per-container resource limits for the consolidated deployment.
 # The instance total is the SUM across the three containers and must resolve to a
-# supported Cloud Run CPU size. Defaults sum to 2 vCPU / 2.5Gi.
+# supported Cloud Run CPU size. Defaults sum to 1 vCPU / 2Gi.
+#
+# Cost break-even (us-central1, always-allocated, no CUD): a consolidated instance
+# runs ~$55/mo at the 1 vCPU default but ~$105-110/mo at 2 vCPU / 2.5Gi — the
+# latter is a wash against a loaded split deployment's idle floor (~$100/mo:
+# always-on daemon + daemon-kept-warm code server). Consolidation only *saves*
+# money at roughly <=1.5 vCPU total; above that it's a topology simplification,
+# not a cost cut. Size up only if the UI or code server is actually starved.
+# If Cloud Run rejects the fractional per-container split at apply time, fall
+# back to whole-CPU containers (1000m each, 3 vCPU total).
 variable "consolidated_resources" {
-  description = "Per-container resource limits for deployment_mode = consolidated"
+  description = "Per-container resource limits for deployment_mode = consolidated. Instance cost scales with the SUM across containers; see the break-even note above this variable."
   type = object({
     webserver   = object({ cpu = string, memory = string })
     daemon      = object({ cpu = string, memory = string })
     code_server = object({ cpu = string, memory = string })
   })
   default = {
-    webserver   = { cpu = "1000m", memory = "1Gi" }
-    code_server = { cpu = "500m", memory = "1Gi" }
-    daemon      = { cpu = "500m", memory = "512Mi" }
+    webserver   = { cpu = "500m", memory = "512Mi" }
+    code_server = { cpu = "250m", memory = "1Gi" }
+    daemon      = { cpu = "250m", memory = "512Mi" }
   }
 }
 

--- a/tf/modules/dagster/variables.tf
+++ b/tf/modules/dagster/variables.tf
@@ -22,6 +22,11 @@ variable "extra_env" {
   description = "Additional plain environment variables injected into every Dagster component (webserver, daemon, code servers, run workers). Use for consumer-domain config like bucket names or secret IDs the app resolves itself."
   type        = map(string)
   default     = {}
+
+  validation {
+    condition     = length(setintersection(keys(var.extra_env), ["GCP_PROJECT_ID", "GCP_REGION", "DAGSTER_HOME", "DAGSTER_LOGS_BUCKET"])) == 0
+    error_message = "extra_env must not override the module-managed env vars GCP_PROJECT_ID, GCP_REGION, DAGSTER_HOME, or DAGSTER_LOGS_BUCKET."
+  }
 }
 
 variable "bucket_grants" {
@@ -237,7 +242,7 @@ variable "iap_allowed_domain" {
 }
 
 variable "custom_domain" {
-  description = "Custom domain for webserver (requires DNS record). Only used when IAP is enabled."
+  description = "Custom domain for the webserver (requires DNS record). Creates a Cloud Run domain mapping whenever set, independent of IAP; pair with an ingress posture that makes the domain reachable."
   type        = string
   default     = null
 }
@@ -258,6 +263,13 @@ variable "path_prefix" {
   description = "URL path prefix the webserver serves under (passed to dagster-webserver --path-prefix). Empty string means served at root. Set to e.g. \"/dagster\" when a reverse proxy forwards a subpath."
   type        = string
   default     = ""
+
+  validation {
+    # Interpolated into Cloud Run probe paths (must start with "/") and passed
+    # to --path-prefix; a trailing slash would yield "//server_info".
+    condition     = var.path_prefix == "" || (startswith(var.path_prefix, "/") && !endswith(var.path_prefix, "/"))
+    error_message = "path_prefix must be empty, or start with \"/\" and not end with \"/\" (e.g. \"/dagster\")."
+  }
 }
 
 variable "webserver_min_instances" {

--- a/tf/modules/dagster/variables.tf
+++ b/tf/modules/dagster/variables.tf
@@ -47,6 +47,48 @@ variable "code_locations" {
   }))
 }
 
+# Deployment topology
+variable "deployment_mode" {
+  description = <<-EOT
+    Dagster topology:
+      - "split"        (default): webserver, daemon, and code server each run as
+                       their own Cloud Run resource. Webserver scales 0->N, daemon
+                       is a single-instance Worker Pool, code server is isolated.
+                       Use when you need horizontal UI scaling or multiple code
+                       locations.
+      - "consolidated": webserver (ingress) + daemon + code server run as three
+                       containers in ONE always-on Cloud Run Service instance.
+                       Lowest cost floor; single code location only. The instance
+                       is pinned to exactly 1 (daemon must be a singleton) and uses
+                       instance-based billing (always-allocated CPU) so the daemon
+                       sidecar is not starved between UI requests.
+  EOT
+  type        = string
+  default     = "split"
+
+  validation {
+    condition     = contains(["split", "consolidated"], var.deployment_mode)
+    error_message = "deployment_mode must be either \"split\" or \"consolidated\"."
+  }
+}
+
+# Per-container resource limits for the consolidated deployment.
+# The instance total is the SUM across the three containers and must resolve to a
+# supported Cloud Run CPU size. Defaults sum to 2 vCPU / 2.5Gi.
+variable "consolidated_resources" {
+  description = "Per-container resource limits for deployment_mode = consolidated"
+  type = object({
+    webserver   = object({ cpu = string, memory = string })
+    daemon      = object({ cpu = string, memory = string })
+    code_server = object({ cpu = string, memory = string })
+  })
+  default = {
+    webserver   = { cpu = "1000m", memory = "1Gi" }
+    code_server = { cpu = "500m", memory = "1Gi" }
+    daemon      = { cpu = "500m", memory = "512Mi" }
+  }
+}
+
 # Optional variables with defaults
 variable "db_name" {
   description = "Database name for Dagster"

--- a/tf/modules/dagster/variables.tf
+++ b/tf/modules/dagster/variables.tf
@@ -14,14 +14,69 @@ variable "cloud_sql_connection_name" {
   type        = string
 }
 
-variable "protobuf_bucket_name" {
-  description = "GCS bucket name for raw protobuf files"
-  type        = string
+# Generic consumer-domain wiring.
+# The module deliberately has no project-specific variables (bucket names,
+# API-credential secrets, etc.); consumers express those through these maps.
+
+variable "extra_env" {
+  description = "Additional plain environment variables injected into every Dagster component (webserver, daemon, code servers, run workers). Use for consumer-domain config like bucket names or secret IDs the app resolves itself."
+  type        = map(string)
+  default     = {}
 }
 
-variable "parquet_bucket_name" {
-  description = "GCS bucket name for compacted parquet files"
-  type        = string
+variable "bucket_grants" {
+  description = <<-EOT
+    GCS bucket IAM grants for the Dagster service accounts. Map key is a stable
+    label (it becomes part of the Terraform resource key — renaming it moves
+    state). Per entry:
+      - bucket:          bucket name to grant on
+      - dagster_role:    role for the primary SA (webserver/daemon/code servers),
+                         or null for no grant
+      - run_worker_role: role for each per-code-location run-worker SA, or null
+  EOT
+  type = map(object({
+    bucket          = string
+    dagster_role    = optional(string)
+    run_worker_role = optional(string)
+  }))
+  default = {}
+}
+
+variable "secret_grants" {
+  description = <<-EOT
+    Secret Manager accessor grants for the Dagster service accounts. Map key is a
+    stable label (part of the Terraform resource key). Per entry:
+      - secret_id:  Secret Manager secret ID
+      - dagster:    grant to the primary SA (default false)
+      - run_worker: grant to each run-worker SA (default true)
+  EOT
+  type = map(object({
+    secret_id  = string
+    dagster    = optional(bool, false)
+    run_worker = optional(bool, true)
+  }))
+  default = {}
+}
+
+variable "run_worker_secret_env" {
+  description = "Environment variables injected into run workers as Secret Manager references: env var name -> secret ID. The secret must also be granted via secret_grants (run_worker = true)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "enable_dbt_hmac_keys" {
+  description = "Issue a GCS HMAC key per run-worker SA and expose it to run workers via Secret Manager-backed env vars (see hmac.tf). For DuckDB/dbt-duckdb httpfs writes to gs:// via the S3-compatible API."
+  type        = bool
+  default     = false
+}
+
+variable "hmac_env_names" {
+  description = "Env var names the run worker receives the HMAC credentials under (only used when enable_dbt_hmac_keys = true). Match what the consumer's profiles.yml/env_var() reads."
+  type = object({
+    key_id = optional(string, "DAGSTER_GCS_HMAC_KEY_ID")
+    secret = optional(string, "DAGSTER_GCS_HMAC_SECRET")
+  })
+  default = {}
 }
 
 # Container images
@@ -165,15 +220,24 @@ variable "labels" {
   default     = {}
 }
 
-# IAP configuration
+# Web exposure mode
+# Three patterns are supported:
+# 1. Public + IAP    — set iap_allowed_domain (+ custom_domain); webserver gets a
+#    public ingress with Google-managed IAP gating the @domain login.
+# 2. Public          — iap_allowed_domain null, public_ingress true: an allUsers
+#    invoker binding is created. Unauthenticated; opt-in only.
+# 3. Private + proxy — iap_allowed_domain null, public_ingress false; no invoker
+#    binding is created and callers invoke through Cloud Run IAM (e.g. another
+#    Cloud Run service forwarding requests with an ID token). Pair with
+#    path_prefix when the proxy mounts the UI under a subpath.
 variable "iap_allowed_domain" {
-  description = "Google Workspace domain for IAP access. Null disables IAP."
+  description = "Google Workspace domain for IAP access. Null disables IAP (see public_ingress for the non-IAP postures)."
   type        = string
   default     = null
 }
 
 variable "custom_domain" {
-  description = "Custom domain for webserver (requires DNS record)"
+  description = "Custom domain for webserver (requires DNS record). Only used when IAP is enabled."
   type        = string
   default     = null
 }
@@ -184,8 +248,26 @@ variable "project_number" {
   default     = null
 }
 
-variable "agencies_secret_id" {
-  description = "Secret Manager secret ID containing agencies.yaml configuration"
+variable "public_ingress" {
+  description = "If true and IAP is disabled, an allUsers run.invoker binding exposes the webserver publicly. If false, access happens via run.invoker IAM granted (outside the module) to a specific caller SA."
+  type        = bool
+  default     = true
+}
+
+variable "path_prefix" {
+  description = "URL path prefix the webserver serves under (passed to dagster-webserver --path-prefix). Empty string means served at root. Set to e.g. \"/dagster\" when a reverse proxy forwards a subpath."
   type        = string
-  default     = "agencies-config"
+  default     = ""
+}
+
+variable "webserver_min_instances" {
+  description = "Minimum webserver instances in split mode. 0 scales to zero (cold start on first UI hit); 1 keeps the UI warm for a small always-on memory cost."
+  type        = number
+  default     = 0
+}
+
+variable "code_server_min_instances" {
+  description = "Minimum code-server instances in split mode. The always-on daemon keeps the code server warm in practice, so 0 is usually fine; 1 makes the warmth explicit and removes sensor-tick cold starts."
+  type        = number
+  default     = 0
 }

--- a/tf/modules/dagster/variables.tf
+++ b/tf/modules/dagster/variables.tf
@@ -283,3 +283,18 @@ variable "code_server_min_instances" {
   type        = number
   default     = 0
 }
+
+# --- External database mode (shared-instance tenancy) ------------------------
+
+variable "manage_database" {
+  description = "Create the database + user in the target instance via the Admin API. Set false when the instance is externally provisioned (e.g. the jarvus-shared-postgres tenant model, which creates an isolated database + SQL-native user itself — API-created users would carry cloudsqlsuperuser and pierce tenant isolation)."
+  type        = bool
+  default     = true
+}
+
+variable "db_password" {
+  description = "Externally-provisioned password for db_user (use with manage_database = false). When null, the module generates one and manages its own user."
+  type        = string
+  sensitive   = true
+  default     = null
+}

--- a/tf/modules/dagster/variables.tf
+++ b/tf/modules/dagster/variables.tf
@@ -74,7 +74,7 @@ variable "deployment_mode" {
 
 # Per-container resource limits for the consolidated deployment.
 # The instance total is the SUM across the three containers and must resolve to a
-# supported Cloud Run CPU size. Defaults sum to 1 vCPU / 2Gi.
+# supported Cloud Run CPU size. Defaults sum to 1 vCPU / 2.5Gi.
 #
 # Cost break-even (us-central1, always-allocated, no CUD): a consolidated instance
 # runs ~$55/mo at the 1 vCPU default but ~$105-110/mo at 2 vCPU / 2.5Gi — the
@@ -94,7 +94,7 @@ variable "consolidated_resources" {
   default = {
     webserver   = { cpu = "500m", memory = "512Mi" }
     code_server = { cpu = "250m", memory = "1Gi" }
-    daemon      = { cpu = "250m", memory = "512Mi" }
+    daemon      = { cpu = "250m", memory = "1Gi" } # matches split's daemon memory; 512Mi risks OOM loops
   }
 }
 

--- a/tf/modules/dagster/webserver.tf
+++ b/tf/modules/dagster/webserver.tf
@@ -1,6 +1,9 @@
 # Cloud Run service for Dagster webserver (UI)
 
 resource "google_cloud_run_v2_service" "webserver" {
+  # Only created in split mode; consolidated mode uses google_cloud_run_v2_service.consolidated
+  count = local.is_split ? 1 : 0
+
   # Use beta provider for IAP support
   provider = google-beta
 
@@ -129,7 +132,7 @@ resource "google_cloud_run_v2_service_iam_member" "webserver_public_invoker" {
   count = var.iap_allowed_domain == null ? 1 : 0
 
   provider = google-beta
-  name     = google_cloud_run_v2_service.webserver.name
+  name     = local.webserver_service_name
   location = var.region
   project  = var.project_id
   role     = "roles/run.invoker"
@@ -141,7 +144,7 @@ resource "google_cloud_run_v2_service_iam_member" "webserver_iap_invoker" {
   count = var.iap_allowed_domain != null ? 1 : 0
 
   provider = google-beta
-  name     = google_cloud_run_v2_service.webserver.name
+  name     = local.webserver_service_name
   location = var.region
   project  = var.project_id
   role     = "roles/run.invoker"
@@ -155,7 +158,7 @@ resource "google_iap_web_cloud_run_service_iam_member" "webserver_domain_access"
   provider               = google-beta
   project                = var.project_number # Must use project number, not ID
   location               = var.region
-  cloud_run_service_name = google_cloud_run_v2_service.webserver.name
+  cloud_run_service_name = local.webserver_service_name
   role                   = "roles/iap.httpsResourceAccessor"
   member                 = "domain:${var.iap_allowed_domain}"
 }
@@ -173,6 +176,6 @@ resource "google_cloud_run_domain_mapping" "webserver" {
   }
 
   spec {
-    route_name = google_cloud_run_v2_service.webserver.name
+    route_name = local.webserver_service_name
   }
 }

--- a/tf/modules/dagster/webserver.tf
+++ b/tf/modules/dagster/webserver.tf
@@ -11,11 +11,16 @@ resource "google_cloud_run_v2_service" "webserver" {
   location = var.region
   project  = var.project_id
 
-  # Enable IAP (Preview feature) - requires BETA launch stage
-  launch_stage = var.iap_allowed_domain != null ? "BETA" : null
-  iap_enabled  = var.iap_allowed_domain != null
+  # Cloud Run IAP is GA (Google auto-promoted deployed services' launch_stage;
+  # forcing BETA here would show as a perpetual GA -> BETA plan diff).
+  iap_enabled = var.iap_allowed_domain != null
 
-  # Allow external access to the UI
+  # Ingress stays INGRESS_TRAFFIC_ALL so other Cloud Run services in the same
+  # project can reach it without a VPC connector — Cloud-Run-to-Cloud-Run
+  # traffic uses the public endpoint by default. Access control happens
+  # entirely at the IAM layer (the `allUsers` invoker binding below is only
+  # created when public_ingress = true; in private mode the consumer grants
+  # `roles/run.invoker` narrowly to a specific SA).
   ingress = "INGRESS_TRAFFIC_ALL"
 
   # Allow replacement during development
@@ -27,7 +32,7 @@ resource "google_cloud_run_v2_service" "webserver" {
     service_account = google_service_account.dagster.email
 
     scaling {
-      min_instance_count = 0
+      min_instance_count = var.webserver_min_instances
       max_instance_count = 2
     }
 
@@ -43,8 +48,13 @@ resource "google_cloud_run_v2_service" "webserver" {
       name  = "webserver"
       image = var.webserver_image
 
-      # Run Dagster webserver
-      command = ["dagster-webserver", "--host", "0.0.0.0", "--port", "3000"]
+      # Run Dagster webserver. --path-prefix lets the UI generate URLs that
+      # match what a reverse proxy forwards (e.g. /dagster). Empty string keeps
+      # the UI at root (the default).
+      command = concat(
+        ["dagster-webserver", "--host", "0.0.0.0", "--port", "3000"],
+        var.path_prefix != "" ? ["--path-prefix", var.path_prefix] : []
+      )
 
       # Mount Cloud SQL socket
       volume_mounts {
@@ -98,7 +108,7 @@ resource "google_cloud_run_v2_service" "webserver" {
       # Startup probe
       startup_probe {
         http_get {
-          path = "/server_info"
+          path = "${var.path_prefix}/server_info"
           port = 3000
         }
         initial_delay_seconds = 5
@@ -110,7 +120,7 @@ resource "google_cloud_run_v2_service" "webserver" {
       # Liveness probe
       liveness_probe {
         http_get {
-          path = "/server_info"
+          path = "${var.path_prefix}/server_info"
           port = 3000
         }
         period_seconds    = 30
@@ -125,11 +135,12 @@ resource "google_cloud_run_v2_service" "webserver" {
   ]
 }
 
-# Public access when IAP is disabled
-# SECURITY WARNING: This allows unauthenticated access to the Dagster UI.
-# Only created when var.iap_allowed_domain is null.
+# Public unauthenticated access — only when the caller asked for it explicitly
+# (public_ingress = true AND no IAP gating). In private mode the caller is
+# expected to add a `roles/run.invoker` binding for the specific service
+# account that will reach this webserver, outside the module.
 resource "google_cloud_run_v2_service_iam_member" "webserver_public_invoker" {
-  count = var.iap_allowed_domain == null ? 1 : 0
+  count = var.iap_allowed_domain == null && var.public_ingress ? 1 : 0
 
   provider = google-beta
   name     = local.webserver_service_name

--- a/tf/storage.tf
+++ b/tf/storage.tf
@@ -16,25 +16,11 @@ resource "google_storage_bucket" "protobuf" {
     }
   }
 
-  lifecycle_rule {
-    condition {
-      age = 30 # Move to Nearline after 30 days
-    }
-    action {
-      type          = "SetStorageClass"
-      storage_class = "NEARLINE"
-    }
-  }
-
-  lifecycle_rule {
-    condition {
-      age = 90 # Move to Coldline after 90 days
-    }
-    action {
-      type          = "SetStorageClass"
-      storage_class = "COLDLINE"
-    }
-  }
+  # NOTE: no SetStorageClass tiering here, on purpose. The bucket holds
+  # millions of tiny protobuf objects; lifecycle transitions bill a Class A
+  # operation per object at the destination class's rate, which cost ~9x the
+  # storage itself (June 2026: ~$305/mo in transition ops vs ~$34/mo storage).
+  # Objects stay STANDARD until the free age-365 delete reaps them.
 
   versioning {
     enabled = false # No versioning needed for append-only archives

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -126,6 +126,18 @@ variable "dagster_code_server_image" {
   default     = "us-central1-docker.pkg.dev/gtfs-archiver/ghcr-remote/jarvusinnovations/gtfs-realtime-archiver/dagster-code-server:latest"
 }
 
+# Dagster deployment topology
+variable "dagster_deployment_mode" {
+  description = "Dagster topology: \"split\" (default, each component its own resource) or \"consolidated\" (webserver + daemon + code server in one always-on instance; lowest cost floor, single code location)."
+  type        = string
+  default     = "split"
+
+  validation {
+    condition     = contains(["split", "consolidated"], var.dagster_deployment_mode)
+    error_message = "dagster_deployment_mode must be either \"split\" or \"consolidated\"."
+  }
+}
+
 # Dagster IAP configuration
 variable "dagster_iap_allowed_domain" {
   description = "Google Workspace domain allowed to access Dagster via IAP (e.g., 'example.com'). Set to null to disable IAP."


### PR DESCRIPTION
## Improvements

- feat(tf): add consolidated Dagster deployment mode [#67] @themightychris
- feat(tf): generalize dagster module into a consumer-agnostic superset [#69] @themightychris

## Technical

- fix(dagster): key run-launcher map by location_name, not module name [#71] @themightychris
- fix(tf): drop protobuf bucket storage-class tiering — transition ops cost 9x the storage @themightychris
- feat(tf): switch Dagster metadata to shared-pg [#73] @themightychris
- docs(claude): note cloning mobility-database-catalogs in /add-agency @themightychris
