### PR TITLE
feat(tf): generalize dagster module into a consumer-agnostic superset

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -67,15 +67,17 @@ gtfs-realtime-archiver/
 │   ├── storage.tf          # GCS bucket with lifecycle
 │   ├── iam.tf              # Service account and permissions
 │   ├── cloudsql.tf         # Cloud SQL PostgreSQL instance
-│   ├── dagster.tf          # Dagster module instantiation
-│   ├── modules/dagster/    # Dagster deployment module
+│   ├── dagster.tf          # Dagster module instantiation (project wiring via extra_env/grants)
+│   ├── dagster_moved.tf    # State moves from the module's generalization (delete after applied)
+│   ├── modules/dagster/    # Dagster deployment module (generic — being extracted to a registry module)
 │   │   ├── main.tf         # Module locals and config
 │   │   ├── webserver.tf    # Dagster UI (Cloud Run Service, split mode)
 │   │   ├── daemon.tf       # Dagster daemon (Worker Pool, split mode)
 │   │   ├── code_server.tf  # gRPC code servers (split mode)
 │   │   ├── consolidated.tf # Single-instance web+daemon+code (consolidated mode)
 │   │   ├── run_worker.tf   # Cloud Run Jobs for runs
-│   │   ├── iam.tf          # Service accounts and permissions
+│   │   ├── iam.tf          # Service accounts, permissions + generic bucket/secret grants
+│   │   ├── hmac.tf         # Optional per-run-worker GCS HMAC keys (dbt-duckdb httpfs)
 │   │   ├── secrets.tf      # DB password secret
 │   │   ├── database.tf     # Database and user creation
 │   │   └── storage.tf      # Logs bucket

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -962,6 +962,14 @@ Note that releases deploy by running `tofu apply` with image `-var`s derived fro
 the release tag (see `.github/workflows/deploy.yaml`) — local applies must supply
 current image versions or they will roll deployed images back.
 
+The `tf/modules/dagster/` module is deliberately generic (no GTFS-specific
+variables): this project's buckets, secrets, and env are wired through the
+module's `extra_env`, `bucket_grants`, `secret_grants`, and `run_worker_secret_env`
+maps in `tf/dagster.tf`. The module also supports private-ingress + reverse-proxy
+exposure (`public_ingress`, `path_prefix`) and optional per-run-worker GCS HMAC
+keys (`enable_dbt_hmac_keys`) used by sibling deployments; it is being extracted
+to a standalone Terraform Registry module.
+
 ---
 
 ## Appendix A: Dependency Justification

--- a/tf/dagster.tf
+++ b/tf/dagster.tf
@@ -12,9 +12,36 @@ module "dagster" {
   region                    = var.region
   cloud_sql_connection_name = google_sql_database_instance.dagster.connection_name
 
-  protobuf_bucket_name = google_storage_bucket.protobuf.name
-  parquet_bucket_name  = google_storage_bucket.parquet.name
-  agencies_secret_id   = var.agencies_secret_id
+  # Consumer-domain wiring: the module is generic, this project's buckets and
+  # secrets are expressed as env + grants (see modules/dagster/variables.tf).
+  extra_env = {
+    GCS_BUCKET_RT_PROTOBUF = google_storage_bucket.protobuf.name
+    GCS_BUCKET_RT_PARQUET  = google_storage_bucket.parquet.name
+    AGENCIES_SECRET_ID     = var.agencies_secret_id
+  }
+
+  bucket_grants = {
+    # Sensors (primary SA) discover feeds by listing; run workers read source
+    # protobufs for compaction.
+    rt-protobuf = {
+      bucket          = google_storage_bucket.protobuf.name
+      dagster_role    = "roles/storage.objectViewer"
+      run_worker_role = "roles/storage.objectViewer"
+    }
+    # Run workers write compacted parquet output.
+    rt-parquet = {
+      bucket          = google_storage_bucket.parquet.name
+      run_worker_role = "roles/storage.objectUser"
+    }
+  }
+
+  secret_grants = {
+    # agencies.yaml config, read by the feeds_metadata asset in run workers.
+    agencies = {
+      secret_id  = var.agencies_secret_id
+      run_worker = true
+    }
+  }
 
   deployment_mode = var.dagster_deployment_mode
 

--- a/tf/dagster_moved.tf
+++ b/tf/dagster_moved.tf
@@ -1,0 +1,30 @@
+# State moves for the dagster module's generalization of project-specific
+# variables into generic bucket_grants / secret_grants maps.
+#
+# The module renamed its consumer-specific IAM resources to generic map-keyed
+# ones; these moves keep the live bindings in place instead of destroy/create
+# (which would open a brief permission gap for running sensors/jobs).
+#
+# Safe to delete once applied (moves are recorded in state) — and MUST be
+# deleted when the module source switches to the Terraform Registry, since
+# moved blocks may not reference resources across module packages.
+
+moved {
+  from = module.dagster.google_storage_bucket_iam_member.dagster_protobuf_reader
+  to   = module.dagster.google_storage_bucket_iam_member.dagster_bucket["rt-protobuf"]
+}
+
+moved {
+  from = module.dagster.google_storage_bucket_iam_member.run_worker_protobuf_reader["gtfsrt"]
+  to   = module.dagster.google_storage_bucket_iam_member.run_worker_bucket["rt-protobuf:gtfsrt"]
+}
+
+moved {
+  from = module.dagster.google_storage_bucket_iam_member.run_worker_parquet_writer["gtfsrt"]
+  to   = module.dagster.google_storage_bucket_iam_member.run_worker_bucket["rt-parquet:gtfsrt"]
+}
+
+moved {
+  from = module.dagster.google_secret_manager_secret_iam_member.run_worker_agencies_config["gtfsrt"]
+  to   = module.dagster.google_secret_manager_secret_iam_member.run_worker_secret["agencies:gtfsrt"]
+}

--- a/tf/modules/dagster/code_server.tf
+++ b/tf/modules/dagster/code_server.tf
@@ -23,9 +23,10 @@ resource "google_cloud_run_v2_service" "code_server" {
     # No VPC connector - use Cloud SQL socket mount
     # Cloud Run connects to Cloud SQL via built-in Cloud SQL Auth Proxy
 
-    # Dagster code server can only have 1 instance
+    # Dagster code server can only have 1 instance. Note the always-on daemon
+    # keeps it warm in practice regardless of the minimum (sensor gRPC polls).
     scaling {
-      min_instance_count = 0
+      min_instance_count = var.code_server_min_instances
       max_instance_count = 1
     }
 

--- a/tf/modules/dagster/consolidated.tf
+++ b/tf/modules/dagster/consolidated.tf
@@ -30,9 +30,9 @@ resource "google_cloud_run_v2_service" "consolidated" {
   location = var.region
   project  = var.project_id
 
-  # Enable IAP (Preview feature) - requires BETA launch stage
-  launch_stage = var.iap_allowed_domain != null ? "BETA" : null
-  iap_enabled  = var.iap_allowed_domain != null
+  # Cloud Run IAP is GA (forcing BETA would show as a perpetual plan diff on
+  # auto-promoted services — see webserver.tf).
+  iap_enabled = var.iap_allowed_domain != null
 
   # Allow external access to the UI
   ingress = "INGRESS_TRAFFIC_ALL"
@@ -132,7 +132,11 @@ resource "google_cloud_run_v2_service" "consolidated" {
       image      = var.webserver_image
       depends_on = ["code-server"]
 
-      command = ["dagster-webserver", "--host", "0.0.0.0", "--port", "3000"]
+      # --path-prefix mirrors webserver.tf (reverse-proxy subpath support)
+      command = concat(
+        ["dagster-webserver", "--host", "0.0.0.0", "--port", "3000"],
+        var.path_prefix != "" ? ["--path-prefix", var.path_prefix] : []
+      )
 
       volume_mounts {
         name       = "cloudsql"
@@ -180,7 +184,7 @@ resource "google_cloud_run_v2_service" "consolidated" {
 
       startup_probe {
         http_get {
-          path = "/server_info"
+          path = "${var.path_prefix}/server_info"
           port = 3000
         }
         initial_delay_seconds = 5
@@ -191,7 +195,7 @@ resource "google_cloud_run_v2_service" "consolidated" {
 
       liveness_probe {
         http_get {
-          path = "/server_info"
+          path = "${var.path_prefix}/server_info"
           port = 3000
         }
         period_seconds    = 30

--- a/tf/modules/dagster/daemon.tf
+++ b/tf/modules/dagster/daemon.tf
@@ -9,8 +9,10 @@ resource "google_cloud_run_v2_worker_pool" "daemon" {
   location = var.region
   project  = var.project_id
 
-  # Worker Pool is in BETA
-  launch_stage = "BETA"
+  # google_cloud_run_v2_worker_pool graduated to GA in 2025; Google
+  # auto-promoted deployed pools' launch_stage. Match that here so
+  # tofu doesn't try to downgrade it back to BETA.
+  launch_stage = "GA"
 
   # Prevent accidental deletion
   deletion_protection = false

--- a/tf/modules/dagster/hmac.tf
+++ b/tf/modules/dagster/hmac.tf
@@ -1,0 +1,78 @@
+# Optional GCS HMAC credentials per run-worker SA (var.enable_dbt_hmac_keys).
+#
+# Why: pipelines that use DuckDB/dbt-duckdb with `materialized = 'external'`
+# write models directly to gs://... locations so separate run-worker containers
+# can resolve `ref()` across runs. Those writes go through DuckDB's httpfs
+# extension, which speaks S3-compatible auth — an HMAC key provides that for
+# GCS.
+#
+# Lifecycle is managed by Terraform: rotation is
+# `tofu taint 'module.<name>.google_storage_hmac_key.dbt_gcs["<location>"]'`
+# + apply. Values flow into Secret Manager and into the run-worker job template
+# via env var refs (see run_worker.tf; names from var.hmac_env_names). HMAC
+# values exist in Terraform state — same trust boundary as the postgres URL and
+# other auto-generated secrets.
+#
+# One key per code location, mirroring the per-code-location run-worker SA
+# pattern; future code locations get their own key automatically.
+
+resource "google_storage_hmac_key" "dbt_gcs" {
+  for_each = var.enable_dbt_hmac_keys ? google_service_account.run_worker : {}
+
+  service_account_email = each.value.email
+  project               = var.project_id
+}
+
+resource "google_secret_manager_secret" "dbt_gcs_hmac_key_id" {
+  for_each  = google_storage_hmac_key.dbt_gcs
+  secret_id = "dbt-gcs-hmac-key-id-${each.key}"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret" "dbt_gcs_hmac_secret" {
+  for_each  = google_storage_hmac_key.dbt_gcs
+  secret_id = "dbt-gcs-hmac-secret-${each.key}"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+}
+
+# No ignore_changes — when the HMAC key is rotated (tofu taint + apply),
+# a new secret version is written and Cloud Run picks it up on next job
+# launch via `version = "latest"`.
+resource "google_secret_manager_secret_version" "dbt_gcs_hmac_key_id" {
+  for_each    = google_storage_hmac_key.dbt_gcs
+  secret      = google_secret_manager_secret.dbt_gcs_hmac_key_id[each.key].id
+  secret_data = each.value.access_id
+}
+
+resource "google_secret_manager_secret_version" "dbt_gcs_hmac_secret" {
+  for_each    = google_storage_hmac_key.dbt_gcs
+  secret      = google_secret_manager_secret.dbt_gcs_hmac_secret[each.key].id
+  secret_data = each.value.secret
+}
+
+# Each run-worker SA can read its own HMAC credentials at job start.
+resource "google_secret_manager_secret_iam_member" "run_worker_hmac_key_id" {
+  for_each = google_storage_hmac_key.dbt_gcs
+
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.dbt_gcs_hmac_key_id[each.key].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.run_worker[each.key].email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "run_worker_hmac_secret" {
+  for_each = google_storage_hmac_key.dbt_gcs
+
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.dbt_gcs_hmac_secret[each.key].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.run_worker[each.key].email}"
+}

--- a/tf/modules/dagster/iam.tf
+++ b/tf/modules/dagster/iam.tf
@@ -82,29 +82,32 @@ resource "google_storage_bucket_iam_member" "run_worker_logs_reader" {
   member = "serviceAccount:${each.value.email}"
 }
 
-# Protobuf bucket read access for primary SA (sensors discover feeds by listing objects)
-resource "google_storage_bucket_iam_member" "dagster_protobuf_reader" {
-  bucket = var.protobuf_bucket_name
-  role   = "roles/storage.objectViewer"
+# Consumer-declared bucket grants (var.bucket_grants).
+# Keys are the consumer's stable labels; run-worker grants are keyed
+# "<grant-label>:<code-location>" so both dimensions stay addressable.
+resource "google_storage_bucket_iam_member" "dagster_bucket" {
+  for_each = { for k, g in var.bucket_grants : k => g if g.dagster_role != null }
+
+  bucket = each.value.bucket
+  role   = each.value.dagster_role
   member = "serviceAccount:${google_service_account.dagster.email}"
 }
 
-# Protobuf bucket read access for run workers (read source data for compaction)
-resource "google_storage_bucket_iam_member" "run_worker_protobuf_reader" {
-  for_each = google_service_account.run_worker
+resource "google_storage_bucket_iam_member" "run_worker_bucket" {
+  for_each = {
+    for pair in setproduct(
+      [for k, g in var.bucket_grants : k if g.run_worker_role != null],
+      keys(var.code_locations)
+      ) : "${pair[0]}:${pair[1]}" => {
+      bucket   = var.bucket_grants[pair[0]].bucket
+      role     = var.bucket_grants[pair[0]].run_worker_role
+      location = pair[1]
+    }
+  }
 
-  bucket = var.protobuf_bucket_name
-  role   = "roles/storage.objectViewer"
-  member = "serviceAccount:${each.value.email}"
-}
-
-# Parquet bucket write access for run workers (write compacted output)
-resource "google_storage_bucket_iam_member" "run_worker_parquet_writer" {
-  for_each = google_service_account.run_worker
-
-  bucket = var.parquet_bucket_name
-  role   = "roles/storage.objectUser"
-  member = "serviceAccount:${each.value.email}"
+  bucket = each.value.bucket
+  role   = each.value.role
+  member = "serviceAccount:${google_service_account.run_worker[each.value.location].email}"
 }
 
 # Cloud SQL client role for service accounts (required for socket connections)
@@ -122,12 +125,29 @@ resource "google_project_iam_member" "run_worker_cloudsql_client" {
   member  = "serviceAccount:${each.value.email}"
 }
 
-# Secret Manager access for run workers (agencies config for feeds_metadata asset)
-resource "google_secret_manager_secret_iam_member" "run_worker_agencies_config" {
-  for_each = google_service_account.run_worker
+# Consumer-declared Secret Manager grants (var.secret_grants).
+resource "google_secret_manager_secret_iam_member" "dagster_secret" {
+  for_each = { for k, g in var.secret_grants : k => g if g.dagster }
 
-  secret_id = var.agencies_secret_id
+  secret_id = each.value.secret_id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${each.value.email}"
+  member    = "serviceAccount:${google_service_account.dagster.email}"
+  project   = var.project_id
+}
+
+resource "google_secret_manager_secret_iam_member" "run_worker_secret" {
+  for_each = {
+    for pair in setproduct(
+      [for k, g in var.secret_grants : k if g.run_worker],
+      keys(var.code_locations)
+      ) : "${pair[0]}:${pair[1]}" => {
+      secret_id = var.secret_grants[pair[0]].secret_id
+      location  = pair[1]
+    }
+  }
+
+  secret_id = each.value.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.run_worker[each.value.location].email}"
   project   = var.project_id
 }

--- a/tf/modules/dagster/main.tf
+++ b/tf/modules/dagster/main.tf
@@ -36,15 +36,17 @@ locals {
   # Common environment variables for all Dagster components
   # Note: Database connection is via DAGSTER_POSTGRES_URL secret (includes socket path)
   # Note: Run worker job name is hardcoded in deploy/dagster.yaml (Permissive config doesn't resolve env vars)
-  common_env = {
-    GCP_PROJECT_ID         = var.project_id
-    GCP_REGION             = var.region
-    DAGSTER_HOME           = "/opt/dagster/dagster_home"
-    GCS_BUCKET_RT_PROTOBUF = var.protobuf_bucket_name
-    GCS_BUCKET_RT_PARQUET  = var.parquet_bucket_name
-    DAGSTER_LOGS_BUCKET    = local.logs_bucket_name
-    AGENCIES_SECRET_ID     = var.agencies_secret_id
-  }
+  # Consumer-domain variables (bucket names, secret IDs the app resolves itself)
+  # come in through var.extra_env — the module defines only Dagster-generic ones.
+  common_env = merge(
+    {
+      GCP_PROJECT_ID      = var.project_id
+      GCP_REGION          = var.region
+      DAGSTER_HOME        = "/opt/dagster/dagster_home"
+      DAGSTER_LOGS_BUCKET = local.logs_bucket_name
+    },
+    var.extra_env
+  )
 }
 
 # Get project data for default compute service account reference

--- a/tf/modules/dagster/run_worker.tf
+++ b/tf/modules/dagster/run_worker.tf
@@ -65,6 +65,41 @@ resource "google_cloud_run_v2_job" "run_worker" {
           }
         }
 
+        # Consumer-declared secret-backed env vars (var.run_worker_secret_env).
+        # Deliberately run-worker only: code servers introspect the asset graph
+        # and shouldn't hold materialization credentials.
+        dynamic "env" {
+          for_each = var.run_worker_secret_env
+          content {
+            name = env.key
+            value_source {
+              secret_key_ref {
+                secret  = env.value
+                version = "latest"
+              }
+            }
+          }
+        }
+
+        # GCS HMAC credentials for DuckDB/dbt-duckdb httpfs writes — see hmac.tf.
+        # Env names come from var.hmac_env_names to match whatever the consumer's
+        # profiles.yml reads via env_var().
+        dynamic "env" {
+          for_each = var.enable_dbt_hmac_keys ? {
+            (var.hmac_env_names.key_id) = google_secret_manager_secret.dbt_gcs_hmac_key_id[each.key].secret_id
+            (var.hmac_env_names.secret) = google_secret_manager_secret.dbt_gcs_hmac_secret[each.key].secret_id
+          } : {}
+          content {
+            name = env.key
+            value_source {
+              secret_key_ref {
+                secret  = env.value
+                version = "latest"
+              }
+            }
+          }
+        }
+
         # Current image for Dagster to identify the code location image
         env {
           name  = "DAGSTER_CURRENT_IMAGE"
@@ -82,6 +117,9 @@ resource "google_cloud_run_v2_job" "run_worker" {
   }
 
   depends_on = [
-    google_secret_manager_secret_iam_member.run_worker_postgres_url
+    google_secret_manager_secret_iam_member.run_worker_postgres_url,
+    # Empty when enable_dbt_hmac_keys = false
+    google_secret_manager_secret_iam_member.run_worker_hmac_key_id,
+    google_secret_manager_secret_iam_member.run_worker_hmac_secret,
   ]
 }

--- a/tf/modules/dagster/variables.tf
+++ b/tf/modules/dagster/variables.tf
@@ -22,6 +22,11 @@ variable "extra_env" {
   description = "Additional plain environment variables injected into every Dagster component (webserver, daemon, code servers, run workers). Use for consumer-domain config like bucket names or secret IDs the app resolves itself."
   type        = map(string)
   default     = {}
+
+  validation {
+    condition     = length(setintersection(keys(var.extra_env), ["GCP_PROJECT_ID", "GCP_REGION", "DAGSTER_HOME", "DAGSTER_LOGS_BUCKET"])) == 0
+    error_message = "extra_env must not override the module-managed env vars GCP_PROJECT_ID, GCP_REGION, DAGSTER_HOME, or DAGSTER_LOGS_BUCKET."
+  }
 }
 
 variable "bucket_grants" {
@@ -237,7 +242,7 @@ variable "iap_allowed_domain" {
 }
 
 variable "custom_domain" {
-  description = "Custom domain for webserver (requires DNS record). Only used when IAP is enabled."
+  description = "Custom domain for the webserver (requires DNS record). Creates a Cloud Run domain mapping whenever set, independent of IAP; pair with an ingress posture that makes the domain reachable."
   type        = string
   default     = null
 }
@@ -258,6 +263,13 @@ variable "path_prefix" {
   description = "URL path prefix the webserver serves under (passed to dagster-webserver --path-prefix). Empty string means served at root. Set to e.g. \"/dagster\" when a reverse proxy forwards a subpath."
   type        = string
   default     = ""
+
+  validation {
+    # Interpolated into Cloud Run probe paths (must start with "/") and passed
+    # to --path-prefix; a trailing slash would yield "//server_info".
+    condition     = var.path_prefix == "" || (startswith(var.path_prefix, "/") && !endswith(var.path_prefix, "/"))
+    error_message = "path_prefix must be empty, or start with \"/\" and not end with \"/\" (e.g. \"/dagster\")."
+  }
 }
 
 variable "webserver_min_instances" {

--- a/tf/modules/dagster/variables.tf
+++ b/tf/modules/dagster/variables.tf
@@ -14,14 +14,69 @@ variable "cloud_sql_connection_name" {
   type        = string
 }
 
-variable "protobuf_bucket_name" {
-  description = "GCS bucket name for raw protobuf files"
-  type        = string
+# Generic consumer-domain wiring.
+# The module deliberately has no project-specific variables (bucket names,
+# API-credential secrets, etc.); consumers express those through these maps.
+
+variable "extra_env" {
+  description = "Additional plain environment variables injected into every Dagster component (webserver, daemon, code servers, run workers). Use for consumer-domain config like bucket names or secret IDs the app resolves itself."
+  type        = map(string)
+  default     = {}
 }
 
-variable "parquet_bucket_name" {
-  description = "GCS bucket name for compacted parquet files"
-  type        = string
+variable "bucket_grants" {
+  description = <<-EOT
+    GCS bucket IAM grants for the Dagster service accounts. Map key is a stable
+    label (it becomes part of the Terraform resource key — renaming it moves
+    state). Per entry:
+      - bucket:          bucket name to grant on
+      - dagster_role:    role for the primary SA (webserver/daemon/code servers),
+                         or null for no grant
+      - run_worker_role: role for each per-code-location run-worker SA, or null
+  EOT
+  type = map(object({
+    bucket          = string
+    dagster_role    = optional(string)
+    run_worker_role = optional(string)
+  }))
+  default = {}
+}
+
+variable "secret_grants" {
+  description = <<-EOT
+    Secret Manager accessor grants for the Dagster service accounts. Map key is a
+    stable label (part of the Terraform resource key). Per entry:
+      - secret_id:  Secret Manager secret ID
+      - dagster:    grant to the primary SA (default false)
+      - run_worker: grant to each run-worker SA (default true)
+  EOT
+  type = map(object({
+    secret_id  = string
+    dagster    = optional(bool, false)
+    run_worker = optional(bool, true)
+  }))
+  default = {}
+}
+
+variable "run_worker_secret_env" {
+  description = "Environment variables injected into run workers as Secret Manager references: env var name -> secret ID. The secret must also be granted via secret_grants (run_worker = true)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "enable_dbt_hmac_keys" {
+  description = "Issue a GCS HMAC key per run-worker SA and expose it to run workers via Secret Manager-backed env vars (see hmac.tf). For DuckDB/dbt-duckdb httpfs writes to gs:// via the S3-compatible API."
+  type        = bool
+  default     = false
+}
+
+variable "hmac_env_names" {
+  description = "Env var names the run worker receives the HMAC credentials under (only used when enable_dbt_hmac_keys = true). Match what the consumer's profiles.yml/env_var() reads."
+  type = object({
+    key_id = optional(string, "DAGSTER_GCS_HMAC_KEY_ID")
+    secret = optional(string, "DAGSTER_GCS_HMAC_SECRET")
+  })
+  default = {}
 }
 
 # Container images
@@ -165,15 +220,24 @@ variable "labels" {
   default     = {}
 }
 
-# IAP configuration
+# Web exposure mode
+# Three patterns are supported:
+# 1. Public + IAP    — set iap_allowed_domain (+ custom_domain); webserver gets a
+#    public ingress with Google-managed IAP gating the @domain login.
+# 2. Public          — iap_allowed_domain null, public_ingress true: an allUsers
+#    invoker binding is created. Unauthenticated; opt-in only.
+# 3. Private + proxy — iap_allowed_domain null, public_ingress false; no invoker
+#    binding is created and callers invoke through Cloud Run IAM (e.g. another
+#    Cloud Run service forwarding requests with an ID token). Pair with
+#    path_prefix when the proxy mounts the UI under a subpath.
 variable "iap_allowed_domain" {
-  description = "Google Workspace domain for IAP access. Null disables IAP."
+  description = "Google Workspace domain for IAP access. Null disables IAP (see public_ingress for the non-IAP postures)."
   type        = string
   default     = null
 }
 
 variable "custom_domain" {
-  description = "Custom domain for webserver (requires DNS record)"
+  description = "Custom domain for webserver (requires DNS record). Only used when IAP is enabled."
   type        = string
   default     = null
 }
@@ -184,8 +248,26 @@ variable "project_number" {
   default     = null
 }
 
-variable "agencies_secret_id" {
-  description = "Secret Manager secret ID containing agencies.yaml configuration"
+variable "public_ingress" {
+  description = "If true and IAP is disabled, an allUsers run.invoker binding exposes the webserver publicly. If false, access happens via run.invoker IAM granted (outside the module) to a specific caller SA."
+  type        = bool
+  default     = true
+}
+
+variable "path_prefix" {
+  description = "URL path prefix the webserver serves under (passed to dagster-webserver --path-prefix). Empty string means served at root. Set to e.g. \"/dagster\" when a reverse proxy forwards a subpath."
   type        = string
-  default     = "agencies-config"
+  default     = ""
+}
+
+variable "webserver_min_instances" {
+  description = "Minimum webserver instances in split mode. 0 scales to zero (cold start on first UI hit); 1 keeps the UI warm for a small always-on memory cost."
+  type        = number
+  default     = 0
+}
+
+variable "code_server_min_instances" {
+  description = "Minimum code-server instances in split mode. The always-on daemon keeps the code server warm in practice, so 0 is usually fine; 1 makes the warmth explicit and removes sensor-tick cold starts."
+  type        = number
+  default     = 0
 }

--- a/tf/modules/dagster/webserver.tf
+++ b/tf/modules/dagster/webserver.tf
@@ -11,11 +11,16 @@ resource "google_cloud_run_v2_service" "webserver" {
   location = var.region
   project  = var.project_id
 
-  # Enable IAP (Preview feature) - requires BETA launch stage
-  launch_stage = var.iap_allowed_domain != null ? "BETA" : null
-  iap_enabled  = var.iap_allowed_domain != null
+  # Cloud Run IAP is GA (Google auto-promoted deployed services' launch_stage;
+  # forcing BETA here would show as a perpetual GA -> BETA plan diff).
+  iap_enabled = var.iap_allowed_domain != null
 
-  # Allow external access to the UI
+  # Ingress stays INGRESS_TRAFFIC_ALL so other Cloud Run services in the same
+  # project can reach it without a VPC connector — Cloud-Run-to-Cloud-Run
+  # traffic uses the public endpoint by default. Access control happens
+  # entirely at the IAM layer (the `allUsers` invoker binding below is only
+  # created when public_ingress = true; in private mode the consumer grants
+  # `roles/run.invoker` narrowly to a specific SA).
   ingress = "INGRESS_TRAFFIC_ALL"
 
   # Allow replacement during development
@@ -27,7 +32,7 @@ resource "google_cloud_run_v2_service" "webserver" {
     service_account = google_service_account.dagster.email
 
     scaling {
-      min_instance_count = 0
+      min_instance_count = var.webserver_min_instances
       max_instance_count = 2
     }
 
@@ -43,8 +48,13 @@ resource "google_cloud_run_v2_service" "webserver" {
       name  = "webserver"
       image = var.webserver_image
 
-      # Run Dagster webserver
-      command = ["dagster-webserver", "--host", "0.0.0.0", "--port", "3000"]
+      # Run Dagster webserver. --path-prefix lets the UI generate URLs that
+      # match what a reverse proxy forwards (e.g. /dagster). Empty string keeps
+      # the UI at root (the default).
+      command = concat(
+        ["dagster-webserver", "--host", "0.0.0.0", "--port", "3000"],
+        var.path_prefix != "" ? ["--path-prefix", var.path_prefix] : []
+      )
 
       # Mount Cloud SQL socket
       volume_mounts {
@@ -98,7 +108,7 @@ resource "google_cloud_run_v2_service" "webserver" {
       # Startup probe
       startup_probe {
         http_get {
-          path = "/server_info"
+          path = "${var.path_prefix}/server_info"
           port = 3000
         }
         initial_delay_seconds = 5
@@ -110,7 +120,7 @@ resource "google_cloud_run_v2_service" "webserver" {
       # Liveness probe
       liveness_probe {
         http_get {
-          path = "/server_info"
+          path = "${var.path_prefix}/server_info"
           port = 3000
         }
         period_seconds    = 30
@@ -125,11 +135,12 @@ resource "google_cloud_run_v2_service" "webserver" {
   ]
 }
 
-# Public access when IAP is disabled
-# SECURITY WARNING: This allows unauthenticated access to the Dagster UI.
-# Only created when var.iap_allowed_domain is null.
+# Public unauthenticated access — only when the caller asked for it explicitly
+# (public_ingress = true AND no IAP gating). In private mode the caller is
+# expected to add a `roles/run.invoker` binding for the specific service
+# account that will reach this webserver, outside the module.
 resource "google_cloud_run_v2_service_iam_member" "webserver_public_invoker" {
-  count = var.iap_allowed_domain == null ? 1 : 0
+  count = var.iap_allowed_domain == null && var.public_ingress ? 1 : 0
 
   provider = google-beta
   name     = local.webserver_service_name


### PR DESCRIPTION
Reconciles drift between this repo's `tf/modules/dagster/` and the sibling deployment's vendored copy, producing the superset that will be extracted to a standalone Terraform Registry module (`terraform-google-dagster-cloud-run`).

## What changed

- **Generic consumer wiring** — `extra_env`, `bucket_grants`, `secret_grants`, `run_worker_secret_env` replace the project-specific `protobuf_bucket_name` / `parquet_bucket_name` / `agencies_secret_id` variables. This repo's wiring moves into `tf/dagster.tf`; `tf/dagster_moved.tf` keeps the live IAM bindings in place (moves, not destroy/create). Delete it after the first apply.
- **Adopted from the sibling copy**: private-ingress + reverse-proxy posture (`public_ingress`, `path_prefix` — wired through probes and consolidated mode), `webserver_min_instances` / `code_server_min_instances` (default 0 = unchanged here), optional per-run-worker GCS HMAC keys for dbt-duckdb httpfs (`enable_dbt_hmac_keys`, off by default).
- **launch_stage GA fixes** — Worker Pools and Cloud Run IAP are GA; forcing BETA produced perpetual `GA -> BETA` plan diffs against auto-promoted live services.

## Verification

- `tofu validate` clean
- Full `tofu plan` against live state: **0 add / 0 destroy**, module resources fully no-op including the state moves; the launch_stage diffs from the previous baseline are gone. Only pre-existing unrelated drift remains (archiver `gcloud` deploy metadata, protobuf bucket lifecycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JdWUqLKKgiCbGDvLhZQttW