### PR TITLE
feat(tf): add on-demand Dagster deployment mode (scale-to-zero)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -74,7 +74,7 @@ gtfs-realtime-archiver/
 │   │   ├── webserver.tf    # Dagster UI (Cloud Run Service, split mode)
 │   │   ├── daemon.tf       # Dagster daemon (Worker Pool, split mode)
 │   │   ├── code_server.tf  # gRPC code servers (split mode)
-│   │   ├── consolidated.tf # Single-instance web+daemon+code (consolidated mode)
+│   │   ├── consolidated.tf # Single-instance web+daemon+code (consolidated + on-demand modes)
 │   │   ├── run_worker.tf   # Cloud Run Jobs for runs
 │   │   ├── iam.tf          # Service accounts, permissions + generic bucket/secret grants
 │   │   ├── hmac.tf         # Optional per-run-worker GCS HMAC keys (dbt-duckdb httpfs)
@@ -344,7 +344,7 @@ Each location gets:
 
 **Deployment Topologies** (`deployment_mode` variable):
 
-The module supports two topologies, selected via `dagster_deployment_mode`
+The module supports three topologies, selected via `dagster_deployment_mode`
 (root) / `deployment_mode` (module). Default is `split`.
 
 - **`split`** (default): webserver, daemon, and code server each run as their
@@ -381,6 +381,34 @@ The module supports two topologies, selected via `dagster_deployment_mode`
   is ~$105–110/mo, a wash against split. Consolidation saves money only at roughly
   ≤1.5 vCPU total; see the note on `consolidated_resources` in
   `tf/modules/dagster/variables.tf`.
+
+- **`on-demand`**: the **same single-instance topology as `consolidated`** (reuses
+  `consolidated.tf` and `consolidated_resources`) but with `min_instance_count = 0`.
+  It scales to zero when idle and cold-starts on the next UI visit. `cpu_idle` stays
+  `false`, which is the key: Cloud Run scales to zero on absence of *requests*, not
+  CPU, so while the instance is up — including the ~15 min idle window before it
+  scales down — the daemon has full CPU and reliably drains the run queue / launches
+  runs, even if the user closes the tab right after clicking Launch. A launched run
+  executes in its own Cloud Run Job and keeps going (writing status to Postgres)
+  after the UI instance scales to zero.
+
+  Use for **demo / occasional-manual-run instances**: pay only while someone is
+  using it (session + the idle window), $0 otherwise. Cloud SQL then becomes the
+  dominant remaining cost. Trade-offs:
+  - **Not for scheduled/sensor workloads** — schedules and sensors only fire while
+    someone has the UI open (the instance is at zero the rest of the time). This
+    mode assumes manual, UI-triggered runs only.
+  - Every session pays a cold start (all three containers, gated by the code
+    server's gRPC startup probe). The code server is still packed as a sidecar
+    container; an optional future optimization is loading code in-process (drop the
+    code-server container, `python_module` workspace) to shave cold-start time, at
+    the cost of prod-parity.
+  - Deferred housekeeping: run-monitoring / retries / zombie-run reaping only run
+    when the daemon is awake, i.e. on the next visit.
+
+  Set `dagster_deployment_mode = "on-demand"`. No `deploy/` changes required — it
+  works with the existing baked `dagster.yaml`/`workspace.yaml` (QueuedRunCoordinator
+  is fine, since the daemon has CPU during the up-window).
 
 **Terraform image variables move with releases — never apply with stale ones**:
 

--- a/tf/modules/dagster/consolidated.tf
+++ b/tf/modules/dagster/consolidated.tf
@@ -1,27 +1,38 @@
-# Consolidated single-instance Dagster deployment (minimal cost floor / "rung 1").
+# Single-instance Dagster deployment: webserver (ingress), daemon, and code server
+# as three containers in ONE Cloud Run Service instance, for a single code location.
 #
-# Runs the webserver (ingress), daemon, and code server as three containers in ONE
-# always-on Cloud Run Service instance, for a single code location.
-#
-# Created only when var.deployment_mode == "consolidated". In that mode the split
-# webserver Service, daemon Worker Pool, and code-server Service are not created.
+# Serves two deployment modes that share this identical topology and differ only in
+# the scaling floor (see the scaling block below):
+#   - "consolidated": min=1, always on. Lowest steady-state cost floor.
+#   - "on-demand":    min=0, scales to zero when idle and cold-starts on the next UI
+#                     visit. Best for demo / occasional-manual-run instances — pay
+#                     only while someone is using it (plus the ~15 min Cloud Run
+#                     idle window), $0 the rest of the time.
+# When either mode is active, the split webserver Service, daemon Worker Pool, and
+# code-server Service are not created.
 #
 # Key constraints (see CLAUDE.md "Deployment Topologies"):
 #   - max_instance_count = 1: the daemon must be a singleton. A second instance
 #     would double-fire schedules and double-evaluate sensors.
-#   - cpu_idle = false (instance-based billing): in a request-billed Service,
-#     sidecars only receive CPU while the ingress container is handling a request,
-#     which would starve the always-on daemon between UI requests. Always-allocated
-#     CPU is required for the daemon to tick reliably.
+#   - cpu_idle = false (instance-based billing) in BOTH modes: a request-billed
+#     Service only gives sidecars CPU while the ingress is handling a request, which
+#     starves the daemon between UI requests. Always-allocated CPU is required for
+#     the daemon to tick reliably. This is orthogonal to min instances: on-demand
+#     still scales to zero (Cloud Run scales down on absence of requests, not CPU),
+#     and while the instance is up — including the idle window — the daemon has full
+#     CPU. So on-demand's daemon drains the run queue / launches runs reliably during
+#     the whole up-window, even if the user closes the tab right after launching.
 #   - Inter-container traffic is over localhost. The code server listens on its
 #     configured port (3030, matching deploy/workspace.yaml); the webserver and
 #     daemon reach it at CODE_SERVER_HOST_<LOC> = "localhost". No separate internal
 #     code-server Service is created, and no gRPC traffic leaves the instance.
 #   - Run workers are unaffected: they are still launched per-run as Cloud Run Jobs
-#     by the CloudRunRunLauncher (see run_worker.tf).
+#     by the CloudRunRunLauncher (see run_worker.tf). In on-demand mode this means a
+#     run keeps executing in its own Job even after the UI instance scales to zero;
+#     it writes status/logs to Postgres independently.
 
 resource "google_cloud_run_v2_service" "consolidated" {
-  count = local.is_consolidated ? 1 : 0
+  count = local.uses_single_instance ? 1 : 0
 
   # Use beta provider for IAP support (parity with the split webserver)
   provider = google-beta
@@ -44,9 +55,10 @@ resource "google_cloud_run_v2_service" "consolidated" {
   template {
     service_account = google_service_account.dagster.email
 
-    # Single always-on instance: the daemon must be unique.
+    # max=1: the daemon must be unique (double-fire otherwise).
+    # min: consolidated pins 1 (always on); on-demand sets 0 (scale to zero).
     scaling {
-      min_instance_count = 1
+      min_instance_count = local.is_ondemand ? 0 : 1
       max_instance_count = 1
     }
 

--- a/tf/modules/dagster/main.tf
+++ b/tf/modules/dagster/main.tf
@@ -14,17 +14,24 @@ locals {
 
   # Deployment topology toggles (see var.deployment_mode)
   is_consolidated = var.deployment_mode == "consolidated"
+  is_ondemand     = var.deployment_mode == "on-demand"
   is_split        = var.deployment_mode == "split"
 
-  # Consolidated mode co-locates a single code location. Pick the (only) entry.
+  # "consolidated" and "on-demand" share the identical single-instance topology
+  # (webserver + daemon + code server in one Service); they differ only in the
+  # scaling floor: consolidated pins min=1 (always on), on-demand sets min=0
+  # (scales to zero when idle, cold-starts on the next UI visit).
+  uses_single_instance = local.is_consolidated || local.is_ondemand
+
+  # Consolidated/on-demand co-locate a single code location. Pick the (only) entry.
   consolidated_location_key = try(keys(var.code_locations)[0], null)
   consolidated_location     = try(var.code_locations[local.consolidated_location_key], null)
 
   # The Service that carries the webserver ingress, used to wire IAP, the public
   # invoker, and the custom domain mapping in both modes. Splats + one() stay safe
   # when the non-active resource has count = 0.
-  webserver_service_name = local.is_consolidated ? one(google_cloud_run_v2_service.consolidated[*].name) : one(google_cloud_run_v2_service.webserver[*].name)
-  webserver_service_uri  = local.is_consolidated ? one(google_cloud_run_v2_service.consolidated[*].uri) : one(google_cloud_run_v2_service.webserver[*].uri)
+  webserver_service_name = local.uses_single_instance ? one(google_cloud_run_v2_service.consolidated[*].name) : one(google_cloud_run_v2_service.webserver[*].name)
+  webserver_service_uri  = local.uses_single_instance ? one(google_cloud_run_v2_service.consolidated[*].uri) : one(google_cloud_run_v2_service.webserver[*].uri)
 
   # Use provided logs bucket or create one
   logs_bucket_name = var.logs_bucket_name != null ? var.logs_bucket_name : google_storage_bucket.logs[0].name

--- a/tf/modules/dagster/variables.tf
+++ b/tf/modules/dagster/variables.tf
@@ -118,17 +118,24 @@ variable "deployment_mode" {
                        locations.
       - "consolidated": webserver (ingress) + daemon + code server run as three
                        containers in ONE always-on Cloud Run Service instance.
-                       Lowest cost floor; single code location only. The instance
-                       is pinned to exactly 1 (daemon must be a singleton) and uses
-                       instance-based billing (always-allocated CPU) so the daemon
-                       sidecar is not starved between UI requests.
+                       Lowest steady-state cost floor; single code location only.
+                       Pinned to exactly 1 instance (daemon must be a singleton),
+                       always-allocated CPU so the daemon isn't starved.
+      - "on-demand":   identical single-instance topology to "consolidated" but
+                       min=0, so it scales to zero when idle and cold-starts on the
+                       next UI visit. Always-allocated CPU while up (including the
+                       ~15 min idle window) keeps the daemon reliable during a
+                       session. Best for demo / occasional-manual-run instances:
+                       pay only while in use, $0 otherwise (Cloud SQL is then the
+                       dominant remaining cost). Not for scheduled/sensor workloads
+                       — those only fire while someone has the UI open.
   EOT
   type        = string
   default     = "split"
 
   validation {
-    condition     = contains(["split", "consolidated"], var.deployment_mode)
-    error_message = "deployment_mode must be either \"split\" or \"consolidated\"."
+    condition     = contains(["split", "consolidated", "on-demand"], var.deployment_mode)
+    error_message = "deployment_mode must be one of \"split\", \"consolidated\", or \"on-demand\"."
   }
 }
 

--- a/tf/storage.tf
+++ b/tf/storage.tf
@@ -16,25 +16,11 @@ resource "google_storage_bucket" "protobuf" {
     }
   }
 
-  lifecycle_rule {
-    condition {
-      age = 30 # Move to Nearline after 30 days
-    }
-    action {
-      type          = "SetStorageClass"
-      storage_class = "NEARLINE"
-    }
-  }
-
-  lifecycle_rule {
-    condition {
-      age = 90 # Move to Coldline after 90 days
-    }
-    action {
-      type          = "SetStorageClass"
-      storage_class = "COLDLINE"
-    }
-  }
+  # NOTE: no SetStorageClass tiering here, on purpose. The bucket holds
+  # millions of tiny protobuf objects; lifecycle transitions bill a Class A
+  # operation per object at the destination class's rate, which cost ~9x the
+  # storage itself (June 2026: ~$305/mo in transition ops vs ~$34/mo storage).
+  # Objects stay STANDARD until the free age-365 delete reaps them.
 
   versioning {
     enabled = false # No versioning needed for append-only archives

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -128,13 +128,13 @@ variable "dagster_code_server_image" {
 
 # Dagster deployment topology
 variable "dagster_deployment_mode" {
-  description = "Dagster topology: \"split\" (default, each component its own resource) or \"consolidated\" (webserver + daemon + code server in one always-on instance; lowest cost floor, single code location)."
+  description = "Dagster topology: \"split\" (default, each component its own resource), \"consolidated\" (webserver + daemon + code server in one always-on instance; lowest steady cost floor, single code location), or \"on-demand\" (same single instance but min=0 — scales to zero when idle, cold-starts on the next UI visit; best for demo / occasional-manual-run instances)."
   type        = string
   default     = "split"
 
   validation {
-    condition     = contains(["split", "consolidated"], var.dagster_deployment_mode)
-    error_message = "dagster_deployment_mode must be either \"split\" or \"consolidated\"."
+    condition     = contains(["split", "consolidated", "on-demand"], var.dagster_deployment_mode)
+    error_message = "dagster_deployment_mode must be one of \"split\", \"consolidated\", or \"on-demand\"."
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a third `dagster_deployment_mode`, **`on-demand`**, for demo / occasional-manual-run instances that should cost ~nothing when idle.

It reuses the existing **consolidated** single-instance topology (`consolidated.tf`, `consolidated_resources`) verbatim and differs in exactly one thing — the scaling floor:

| | consolidated | on-demand |
|---|---|---|
| `min_instance_count` | 1 (always on) | **0 (scales to zero)** |
| `max_instance_count` | 1 | 1 |
| `cpu_idle` | false | false |

## Why `cpu_idle = false` even with `min = 0`

Cloud Run scales to zero on absence of **requests**, not CPU — so always-allocated CPU and scale-to-zero coexist. While the instance is up (including the ~15 min idle window before it scales down) the daemon has full CPU and reliably drains the run queue / launches runs, even if the user closes the tab right after clicking Launch. A launched run executes in its own Cloud Run Job and keeps going after the UI instance scales to zero, writing status to Postgres independently. ([autoscaling docs](https://docs.cloud.google.com/run/docs/about-instance-autoscaling))

## Packing

The code server stays packed as the **third sidecar container** (localhost gRPC) — same as consolidated. No separate code-server Service. (An optional future cold-start optimization is in-process code loading; not in this PR.)

## Trade-offs (documented in CLAUDE.md)

- **Not for scheduled/sensor workloads** — schedules/sensors only fire while someone has the UI open.
- Every session pays a cold start (three containers, gated by the code server's gRPC startup probe).
- Run monitoring / retries / zombie-run reaping only run when the daemon is awake (next visit).

## Deploy impact

None beyond the mode flag. Works with the existing baked `dagster.yaml` / `workspace.yaml` (QueuedRunCoordinator is fine since the daemon has CPU during the up-window). Set `dagster_deployment_mode = "on-demand"`.

> ⚠️ This PR currently also contains the pre-existing `c545fc7` (protobuf storage-class fix) because it's on local `develop` but not yet on `origin/develop`. Push `develop` (`git push origin develop`) and this PR will show only the on-demand commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)