### PR TITLE
fix(dagster): key run-launcher map by location_name, not module name

### DIFF
--- a/deploy/dagster.yaml
+++ b/deploy/dagster.yaml
@@ -17,9 +17,10 @@ run_launcher:
     region:
       env: GCP_REGION
     job_name_by_code_location:
-      # Key must match the module name Dagster uses for the code location
-      # Value is the Cloud Run job name from Terraform
-      dagster_pipeline.definitions: dagster-run-worker-gtfsrt
+      # Key must match workspace.yaml's location_name — CloudRunRunLauncher
+      # resolves the job by remote_job_origin.location_name, NOT the module
+      # name. Value is the Cloud Run job name from Terraform.
+      gtfsrt: dagster-run-worker-gtfsrt
     run_timeout: 86400
 
 # Queued run coordinator for managing concurrent runs


### PR DESCRIPTION
`CloudRunRunLauncher` resolves the run-worker job by `remote_job_origin.location_name` ([run_launcher.py:69](https://github.com/dagster-io/community-integrations/blob/main/libraries/dagster-contrib-gcp/dagster_contrib_gcp/cloud_run/run_launcher.py)), and `deploy/workspace.yaml` sets `location_name: gtfsrt` — but `deploy/dagster.yaml` keyed `job_name_by_code_location` by the **module name** (`dagster_pipeline.definitions`), with a comment asserting that as the rule.

How it drifted: 7324433 deliberately switched the key to the module name, which was correct **at the time** because workspace.yaml had no explicit `location_name` (Dagster derives the location name from the module). The explicit `location_name: gtfsrt` arrived later, changing what the launcher looks up. Production works only because the deployed images were baked from an older consistent pair — the next image rebuild would bake the mismatch and every run launch would fail with `No run launcher defined for code location: gtfsrt`.

Surfaced while generalizing this config into the extracted module's kit templates (JarvusInnovations/terraform-google-dagster-cloud-run#2), which encode the location_name rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JdWUqLKKgiCbGDvLhZQttW