### PR TITLE
feat(tf): switch Dagster metadata to shared-pg

### DIFF
--- a/tf/dagster.tf
+++ b/tf/dagster.tf
@@ -5,12 +5,27 @@ data "google_project" "current" {
   project_id = var.project_id
 }
 
+# Shared-pg switchover (2026-07): Dagster metadata now lives in the
+# multi-tenant jarvus-shared-postgres instance (tenant: dagster_gtfsrt; see
+# infra-ops projects/shared-postgres). The local dagster-postgres instance
+# (PG14, EOL pressure) is retained for rollback until the cleanup PR.
+data "google_secret_manager_secret_version" "shared_pg_password" {
+  secret = "shared-pg-dagster_gtfsrt-password"
+}
+
 module "dagster" {
   source = "./modules/dagster"
 
   project_id                = var.project_id
   region                    = var.region
-  cloud_sql_connection_name = google_sql_database_instance.dagster.connection_name
+  cloud_sql_connection_name = "jarvus-shared-postgres:us-east4:shared-pg"
+
+  # External-database mode: the shared root provisions the isolated tenant
+  # database + SQL-native user; the module only composes the URL.
+  manage_database = false
+  db_name         = "dagster_gtfsrt"
+  db_user         = "dagster_gtfsrt_app"
+  db_password     = data.google_secret_manager_secret_version.shared_pg_password.secret_data
 
   # Consumer-domain wiring: the module is generic, this project's buckets and
   # secrets are expressed as env + grants (see modules/dagster/variables.tf).
@@ -67,7 +82,4 @@ module "dagster" {
     project = "gtfs-rt-archiver"
   }
 
-  depends_on = [
-    google_sql_database_instance.dagster
-  ]
 }

--- a/tf/modules/dagster/database.tf
+++ b/tf/modules/dagster/database.tf
@@ -1,5 +1,7 @@
 # Create database in the provided Cloud SQL instance
 resource "google_sql_database" "dagster" {
+  count = var.manage_database ? 1 : 0
+
   name     = var.db_name
   instance = local.cloud_sql_instance_name
   project  = var.project_id
@@ -7,6 +9,8 @@ resource "google_sql_database" "dagster" {
 
 # Create database user
 resource "google_sql_user" "dagster" {
+  count = var.manage_database ? 1 : 0
+
   name     = var.db_user
   instance = local.cloud_sql_instance_name
   password = random_password.db_password.result

--- a/tf/modules/dagster/outputs.tf
+++ b/tf/modules/dagster/outputs.tf
@@ -50,7 +50,7 @@ output "run_worker_job_names" {
 # Database outputs
 output "database_name" {
   description = "Name of the Dagster database"
-  value       = google_sql_database.dagster.name
+  value       = coalesce(one(google_sql_database.dagster[*].name), var.db_name)
 }
 
 # Logs bucket output

--- a/tf/modules/dagster/secrets.tf
+++ b/tf/modules/dagster/secrets.tf
@@ -5,6 +5,10 @@ resource "random_password" "db_password" {
   override_special = "_-" # Conservative set safe for connection strings
 }
 
+locals {
+  effective_db_password = var.db_password != null ? var.db_password : random_password.db_password.result
+}
+
 # Store database password in Secret Manager
 resource "google_secret_manager_secret" "db_password" {
   secret_id = "dagster-db-password"
@@ -19,7 +23,7 @@ resource "google_secret_manager_secret" "db_password" {
 
 resource "google_secret_manager_secret_version" "db_password" {
   secret      = google_secret_manager_secret.db_password.id
-  secret_data = random_password.db_password.result
+  secret_data = local.effective_db_password
 }
 
 # Full PostgreSQL connection URL for Unix socket connections
@@ -37,5 +41,5 @@ resource "google_secret_manager_secret" "postgres_url" {
 
 resource "google_secret_manager_secret_version" "postgres_url" {
   secret      = google_secret_manager_secret.postgres_url.id
-  secret_data = "postgresql://${var.db_user}:${random_password.db_password.result}@/${var.db_name}?host=${local.db_socket_path}"
+  secret_data = "postgresql://${var.db_user}:${local.effective_db_password}@/${var.db_name}?host=${local.db_socket_path}"
 }

--- a/tf/modules/dagster/variables.tf
+++ b/tf/modules/dagster/variables.tf
@@ -283,3 +283,18 @@ variable "code_server_min_instances" {
   type        = number
   default     = 0
 }
+
+# --- External database mode (shared-instance tenancy) ------------------------
+
+variable "manage_database" {
+  description = "Create the database + user in the target instance via the Admin API. Set false when the instance is externally provisioned (e.g. the jarvus-shared-postgres tenant model, which creates an isolated database + SQL-native user itself — API-created users would carry cloudsqlsuperuser and pierce tenant isolation)."
+  type        = bool
+  default     = true
+}
+
+variable "db_password" {
+  description = "Externally-provisioned password for db_user (use with manage_database = false). When null, the module generates one and manages its own user."
+  type        = string
+  sensitive   = true
+  default     = null
+}


### PR DESCRIPTION
Moves Dagster's metadata DB from the dedicated `dagster-postgres` instance (**PG14 — approaching EOL, which this sidesteps entirely**) to the multi-tenant `jarvus-shared-postgres:us-east4:shared-pg` (tenant `dagster_gtfsrt`, provisioned by infra-ops `projects/shared-postgres`).

Module gains an external-database mode (`manage_database = false` + `db_password`) — the shared root owns database/user creation because Admin-API-created users join `cloudsqlsuperuser` and would pierce tenant isolation.

**Do not merge before the data migration** (runbook in commit message). Note for whoever applies: this repo's tf state has image-pin drift vs CI-deployed versions — plan with `-var` image overrides (see PR #67 discussion). Same module change is staged in the private demo project's repo; if the deployment-mode work (PR #67 / on-demand mode) rearranges the module, this PR is small enough to rebase onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UubgT92tLepcj9naR8K2Pq