### PR TITLE
fix(dagster): launcher map key must match the runtime location name (module path)

### DIFF
--- a/deploy/dagster.yaml
+++ b/deploy/dagster.yaml
@@ -17,10 +17,14 @@ run_launcher:
     region:
       env: GCP_REGION
     job_name_by_code_location:
-      # Key must match workspace.yaml's location_name — CloudRunRunLauncher
-      # resolves the job by remote_job_origin.location_name, NOT the module
-      # name. Value is the Cloud Run job name from Terraform.
-      gtfsrt: dagster-run-worker-gtfsrt
+      # Key must match the code location's RUNTIME name. The webserver and
+      # daemon load code IN-PROCESS via pyproject.toml [tool.dagster] (the
+      # baked workspace.yaml is NOT loaded — dagster only discovers it from
+      # the working directory, and the image keeps it in dagster_home/), so
+      # the location is named after the module. If workspace-based loading is
+      # ever wired up for real (issue #78), this key becomes that file's
+      # location_name.
+      dagster_pipeline.definitions: dagster-run-worker-gtfsrt
     run_timeout: 86400
 
 # Queued run coordinator for managing concurrent runs


### PR DESCRIPTION
**Production run-launching is broken since v0.9.1 deployed** (first scheduled tick after deploy, 2026-07-10 02:00 UTC, failed dequeue with `KeyError: 'dagster_pipeline.definitions'`; runs stuck QUEUED — raw archiving unaffected).

Root cause (now fully understood, revising #71's analysis): `dagster-webserver`/`dagster-daemon` run without `-w` and there is no `workspace.yaml` in the image WORKDIR — dagster's discovery falls through to `pyproject.toml [tool.dagster]` and loads the code location **in-process** under the module-path name. The baked `deploy/workspace.yaml` (`location_name: gtfsrt`) has never been loaded by any process, and the code-server Service has nothing connecting to it. #71 keyed the launcher map to a file that is dead configuration; this restores the runtime-true key with a comment explaining the mechanism.

After deploy, the ~54 queued runs (2026-07-09 backfill + restarted schedules) should dequeue and launch on their own — their stored origin matches the restored key.

Follow-up decision tracked separately: wire real workspace-file loading (making the gRPC code-server architecture actual) vs. embracing in-process loading and removing the unused code-server Service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JdWUqLKKgiCbGDvLhZQttW