### PR TITLE
feat: add five midwest transit agencies

### DIFF
--- a/agencies.yaml
+++ b/agencies.yaml
@@ -303,3 +303,64 @@ agencies:
         url: http://nycferry.connexionz.net/rtt/public/utility/gtfsrealtime.aspx/tripupdate
       - feed_type: service_alerts
         url: http://nycferry.connexionz.net/rtt/public/utility/gtfsrealtime.aspx/alert
+
+  # "wrta" is also Worcester (MA) RTA — id disambiguated to Youngstown
+  - id: wrta-youngstown
+    name: Western Reserve Transit Authority (Youngstown)
+    schedule_url: https://myvalleystops.wrtaonline.com/InfoPoint/gtfs-zip.ashx
+    feeds:
+      - feed_type: vehicle_positions
+        url: https://myvalleystops.wrtaonline.com/infopoint/GTFS-Realtime.ashx?Type=VehiclePosition
+      - feed_type: trip_updates
+        url: https://myvalleystops.wrtaonline.com/infopoint/GTFS-Realtime.ashx?Type=TripUpdate
+      - feed_type: service_alerts
+        url: https://myvalleystops.wrtaonline.com/infopoint/GTFS-Realtime.ashx?Type=Alert
+
+  # Unified feed set covers bus + rail (no per-mode split)
+  - id: gcrta
+    name: Greater Cleveland RTA
+    schedule_url: https://www.riderta.com/sites/default/files/gtfs/latest/google_transit.zip
+    feeds:
+      - feed_type: vehicle_positions
+        url: https://gtfs-rt.gcrta.vontascloud.com/TMGTFSRealTimeWebService/Vehicle/VehiclePositions.pb
+      - feed_type: trip_updates
+        url: https://gtfs-rt.gcrta.vontascloud.com/TMGTFSRealTimeWebService/TripUpdate/TripUpdates.pb
+      - feed_type: service_alerts
+        url: https://gtfs-rt.gcrta.vontascloud.com/TMGTFSRealTimeWebService/Alert/Alerts.pb
+
+  - id: citybus-lafayette
+    name: CityBus of Greater Lafayette
+    schedule_url: https://bus.gocitybus.com/GTFSRT/citybus-lafayette-in-us.zip
+    feeds:
+      - feed_type: vehicle_positions
+        url: https://bus.gocitybus.com/GTFSRT/GTFS_VehiclePositions.pb
+      - feed_type: trip_updates
+        url: https://bus.gocitybus.com/GTFSRT/GTFS_TripUpdates.pb
+      - feed_type: service_alerts
+        url: https://bus.gocitybus.com/GTFSRT/GTFS_ServiceAlerts.pb
+
+  # RT endpoints are undocumented first-party (GMV Syncromatics conventional
+  # paths); VP and SA declare gtfs_realtime_version "1.0", TU declares "2.0"
+  - id: bcrta
+    name: Butler County RTA
+    schedule_url: https://www.buztrakr.com/gtfs
+    feeds:
+      - feed_type: vehicle_positions
+        url: https://www.buztrakr.com/gtfs-rt/vehiclepositions
+      - feed_type: trip_updates
+        url: https://www.buztrakr.com/gtfs-rt/tripupdates
+      - feed_type: service_alerts
+        url: https://www.buztrakr.com/gtfs-rt/alerts
+
+  # RT endpoints are undocumented first-party (Clever Devices BusTime paths,
+  # unauthenticated; the BusTime JSON API is separate and key-gated)
+  - id: dayton-rta
+    name: Greater Dayton RTA
+    schedule_url: https://proc.greaterdaytonrta.org/gtfs/google_transit.zip
+    feeds:
+      - feed_type: vehicle_positions
+        url: https://ridetime.greaterdaytonrta.org/gtfsrt/vehicles
+      - feed_type: trip_updates
+        url: https://ridetime.greaterdaytonrta.org/gtfsrt/trips
+      - feed_type: service_alerts
+        url: https://ridetime.greaterdaytonrta.org/gtfsrt/alerts


### PR DESCRIPTION
Adds five agencies to `agencies.yaml`, all with vehicle_positions, trip_updates, and service_alerts plus a static GTFS `schedule_url`. All endpoints are public (no auth required, no new secrets) and every URL was curl-verified live on 2026-07-10 (HTTP 200 + GTFS-RT FeedMessage header bytes for RT feeds; zip magic bytes + required GTFS files for schedules).

| Agency | id | Platform | Notes |
|---|---|---|---|
| Western Reserve Transit Authority (Youngstown OH) | `wrta-youngstown` | Avail InfoPoint | id disambiguated from Worcester (MA) WRTA |
| Greater Cleveland RTA | `gcrta` | Vontas Cloud | Unified bus+rail feed set; URLs from riderta.com/developers (MDB catalog's RT entries point at the dead `gtfs.gcrta.org` host — correction being submitted upstream) |
| CityBus of Greater Lafayette (IN) | `citybus-lafayette` | Avail | Alerts feed currently header-only (no active alerts) |
| Butler County RTA (OH) | `bcrta` | GMV Syncromatics | RT endpoints are undocumented vendor-conventional paths; VP/SA declare gtfs_realtime_version "1.0" (archiver stores raw bytes, no version check) |
| Greater Dayton RTA | `dayton-rta` | Clever Devices BusTime | RT endpoints are undocumented vendor-conventional paths; verified live (feed timestamp current, trip IDs cross-match schedule) |

Also researched **CARTS** (Community Action Rural Transit, Columbiana County OH) and skipped it: demand-response/dial-a-ride only — no public GTFS or GTFS-RT exists (NTD notes the agency deliberately does not host its GTFS publicly).

Config validated through the real models: `AgenciesFileConfig` parse + `flatten_agencies()` → 19 agencies, 68 feeds; the 15 new feeds inherit default intervals (20s VP/TU, 60s SA).

## Follow-up after merge

**This PR does not change production by itself** — prod reads agency config from the `agencies-config` secret, not from git. After merging, run `/deploy-agencies` to push the new config to Secret Manager and restart the Cloud Run service, then verify the 15 new feeds via `/health/feeds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)