### PR TITLE
feat(ci): deploy agencies config via GitHub Actions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -35,7 +35,7 @@ See [DESIGN.md](../DESIGN.md) for detailed technical specifications.
 
 ```
 gtfs-realtime-archiver/
-├── .github/workflows/      # CI/CD (lint, test, build, push, pages)
+├── .github/workflows/      # CI/CD (lint, test, build, push, pages, agency config deploy)
 ├── .claude/                # AI assistant guidelines (this directory)
 ├── .dagster_home/          # Dagster configuration
 ├── site/                   # Static site for gtfsrt.io (GitHub Pages)

--- a/.claude/commands/deploy-agencies.md
+++ b/.claude/commands/deploy-agencies.md
@@ -4,7 +4,29 @@ Deploy changes from local `agencies.yaml` to the production GTFS-RT archiver ser
 
 **Optional filter:** $ARGUMENTS
 
-## Workflow
+## Preferred Path: CI Deployment
+
+Agency config deploys are automated via
+`.github/workflows/deploy-agencies.yaml`: any push to `develop` that touches
+`agencies.yaml` (i.e. merging an agency PR) validates the config against the
+Pydantic models, checks for drift against the deployed secret, pushes a new
+secret version, restarts the archiver, and verifies health — the same steps
+as the manual workflow below. It can also be run on demand via
+`gh workflow run deploy-agencies.yaml --ref develop`.
+
+So the normal flow is: open a PR changing `agencies.yaml`, merge to
+`develop`, and watch the "Deploy Agencies" run
+(`gh run watch $(gh run list --workflow=deploy-agencies.yaml --limit 1 --json databaseId --jq '.[0].databaseId')`).
+
+**The CI run fails intentionally on drift** — if the deployed secret contains
+agencies missing from git (someone deployed directly), CI aborts rather than
+silently removing them from production. Reconcile by committing the missing
+agencies to git (or removing them deliberately in a PR), then re-run.
+
+Use the manual workflow below when CI can't: emergency config pushes that
+can't wait for a PR, rollbacks, or interactive drift reconciliation.
+
+## Manual Workflow
 
 ### Step 1: Fetch Currently Deployed Configuration
 
@@ -199,7 +221,7 @@ gcloud run services update gtfs-rt-archiver \
 ## Reference
 
 | Setting | Value |
-|---------|-------|
+| --------- | ------- |
 | Secret ID | `agencies-config` |
 | Project | `gtfs-archiver` |
 | Service | `gtfs-rt-archiver` |

--- a/.claude/commands/deploy-agencies.md
+++ b/.claude/commands/deploy-agencies.md
@@ -18,10 +18,17 @@ So the normal flow is: open a PR changing `agencies.yaml`, merge to
 `develop`, and watch the "Deploy Agencies" run
 (`gh run watch $(gh run list --workflow=deploy-agencies.yaml --limit 1 --json databaseId --jq '.[0].databaseId')`).
 
-**The CI run fails intentionally on drift** — if the deployed secret contains
-agencies missing from git (someone deployed directly), CI aborts rather than
-silently removing them from production. Reconcile by committing the missing
-agencies to git (or removing them deliberately in a PR), then re-run.
+**The CI run fails intentionally whenever a deploy would remove agencies**
+that are in the deployed secret but not in git. The guard can't distinguish
+the two causes, so handle by cause:
+
+- **Out-of-band drift** (someone deployed directly to the secret without
+  committing): commit the missing agencies to git, merge, and the next run
+  proceeds.
+- **Intentional removal** (a merged PR deletes an agency): the push-triggered
+  run will fail — that's the acknowledgment gate, not a bug. Complete the
+  removal with:
+  `gh workflow run deploy-agencies.yaml --ref develop -f allow_removals=true`
 
 Use the manual workflow below when CI can't: emergency config pushes that
 can't wait for a PR, rollbacks, or interactive drift reconciliation.

--- a/.github/workflows/deploy-agencies.yaml
+++ b/.github/workflows/deploy-agencies.yaml
@@ -1,0 +1,191 @@
+name: Deploy Agencies
+
+on:
+  push:
+    branches: [develop]
+    paths: [agencies.yaml]
+  workflow_dispatch:
+
+# Serialize config deployments; never cancel one mid-flight
+concurrency:
+  group: deploy-agencies
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT_ID: gtfs-archiver
+  GCP_REGION: us-central1
+  SERVICE_NAME: gtfs-rt-archiver
+  SECRET_ID: agencies-config
+
+jobs:
+  deploy-agencies:
+    name: Deploy Agencies Configuration
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup ASDF
+        uses: asdf-vm/actions/setup@v4
+
+      - name: Restore ASDF tools from cache
+        id: asdf-tools-cache
+        uses: actions/cache@v5
+        with:
+          key: asdf-tools-${{ hashFiles('.tool-versions') }}
+          restore-keys: |
+            asdf-tools-
+          path: |
+            ${{ env.ASDF_DIR }}/plugins
+            ${{ env.ASDF_DIR }}/installs
+
+      - name: Install ASDF tools on cache miss
+        if: ${{ steps.asdf-tools-cache.outputs.cache-hit != 'true' }}
+        uses: asdf-vm/actions/install@v4
+
+      - name: Reshim ASDF tools
+        shell: bash
+        run: asdf reshim
+
+      - name: Install dependencies
+        run: uv sync --frozen --dev
+
+      - name: Validate configuration against models
+        id: validate
+        run: |
+          uv run python - <<'EOF' | tee /tmp/validate.out
+          import yaml
+          from gtfs_rt_archiver.models import AgenciesFileConfig
+          from gtfs_rt_archiver.config import flatten_agencies
+
+          parsed = AgenciesFileConfig.model_validate(yaml.safe_load(open("agencies.yaml")))
+          flat = flatten_agencies(parsed)
+          ids = [a.id for a in parsed.agencies]
+          assert len(ids) == len(set(ids)), "duplicate agency ids"
+          print(f"agencies={len(parsed.agencies)}")
+          print(f"feeds={len(flat)}")
+          EOF
+          grep -E "^(agencies|feeds)=" /tmp/validate.out >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/${{ vars.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-actions/providers/github-provider
+          service_account: github-actions-deploy@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Check for drift against deployed configuration
+        id: drift
+        run: |
+          gcloud secrets versions access latest \
+            --secret="$SECRET_ID" \
+            --project="$GCP_PROJECT_ID" > /tmp/deployed-agencies.yaml
+
+          if cmp -s /tmp/deployed-agencies.yaml agencies.yaml; then
+            echo "Deployed configuration is identical; nothing to deploy."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+          # Agencies present in the deployed secret but missing from git mean
+          # someone deployed directly without committing. Deploying now would
+          # silently remove them from production — fail so a human reconciles
+          # (commit the missing agency to git, or intentionally remove it in a
+          # PR, then re-run).
+          missing=$(comm -23 \
+            <(grep -E "^  - id:" /tmp/deployed-agencies.yaml | sort) \
+            <(grep -E "^  - id:" agencies.yaml | sort))
+          if [ -n "$missing" ]; then
+            echo "::error::Deployed secret contains agencies missing from agencies.yaml:"
+            echo "$missing"
+            echo "Reconcile them into git (or remove them intentionally via PR) before deploying."
+            exit 1
+          fi
+
+          {
+            echo "## Configuration diff (deployed → local)"
+            echo '```diff'
+            diff -u /tmp/deployed-agencies.yaml agencies.yaml || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update secret
+        if: steps.drift.outputs.changed == 'true'
+        run: |
+          gcloud secrets versions add "$SECRET_ID" \
+            --project="$GCP_PROJECT_ID" \
+            --data-file=agencies.yaml
+
+      - name: Restart archiver service
+        if: steps.drift.outputs.changed == 'true'
+        run: |
+          # Secret volumes are cached per revision; force a new revision
+          gcloud run services update "$SERVICE_NAME" \
+            --region="$GCP_REGION" \
+            --project="$GCP_PROJECT_ID" \
+            --update-env-vars="DEPLOY_TIMESTAMP=$(date +%s)"
+
+      - name: Verify deployment
+        if: steps.drift.outputs.changed == 'true'
+        run: |
+          SERVICE_URL=$(gcloud run services describe "$SERVICE_NAME" \
+            --region="$GCP_REGION" \
+            --project="$GCP_PROJECT_ID" \
+            --format='value(status.url)')
+          echo "Service URL: $SERVICE_URL"
+
+          for i in {1..30}; do
+            if curl -sf "${SERVICE_URL}/health" > /tmp/health.json 2>/dev/null; then
+              break
+            fi
+            echo "Attempt $i/30: service not ready yet..."
+            sleep 10
+          done
+
+          jq . /tmp/health.json
+          status=$(jq -r .status /tmp/health.json)
+          scheduled=$(jq -r .scheduler.jobs_scheduled /tmp/health.json)
+          expected="${{ steps.validate.outputs.feeds }}"
+
+          if [ "$status" != "healthy" ]; then
+            echo "::error::Service is not healthy after restart"
+            exit 1
+          fi
+          if [ "$scheduled" != "$expected" ]; then
+            echo "::error::Scheduler has $scheduled jobs but the config defines $expected feeds"
+            exit 1
+          fi
+          echo "Healthy with $scheduled/$expected feeds scheduled."
+
+      - name: Report per-feed status
+        if: steps.drift.outputs.changed == 'true'
+        run: |
+          SERVICE_URL=$(gcloud run services describe "$SERVICE_NAME" \
+            --region="$GCP_REGION" \
+            --project="$GCP_PROJECT_ID" \
+            --format='value(status.url)')
+
+          # Give feeds one interval cycle to complete their first fetch.
+          # Individual feed failures don't fail the deploy — agency endpoints
+          # can be legitimately down at any time; this is a visibility report.
+          sleep 75
+          {
+            echo "## Per-feed status (75s after restart)"
+            echo ""
+            echo "| Feed | Last success |"
+            echo "| ---- | ------------ |"
+            curl -s "${SERVICE_URL}/health/feeds" | jq -r \
+              '.[] | "| \(.feed_id) | \(if .last_success_seconds_ago == null then "none yet ⚠️" else "\(.last_success_seconds_ago)s ago" end) |"'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          never=$(curl -s "${SERVICE_URL}/health/feeds" | jq -r '[.[] | select(.last_success_seconds_ago == null)] | length')
+          if [ "$never" != "0" ]; then
+            echo "::warning::$never feed(s) have not completed a successful fetch yet — check the summary table"
+          fi

--- a/.github/workflows/deploy-agencies.yaml
+++ b/.github/workflows/deploy-agencies.yaml
@@ -94,31 +94,35 @@ jobs:
             --secret="$SECRET_ID" \
             --project="$GCP_PROJECT_ID" > /tmp/deployed-agencies.yaml
 
-          if cmp -s /tmp/deployed-agencies.yaml agencies.yaml; then
-            echo "Deployed configuration is identical; nothing to deploy."
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "changed=true" >> "$GITHUB_OUTPUT"
-
+          # Compare parsed YAML, not raw bytes/grepped text: formatting-only
+          # differences (whitespace, key order) aren't worth a new revision,
+          # and formatting can't be allowed to mask a removed agency.
           # Agencies present in the deployed secret but absent from git would
-          # be dropped from production by this deploy. That's either an
-          # out-of-band direct-to-secret deploy (must be reconciled into git)
-          # or an intentional removal PR (must be acknowledged via the
-          # allow_removals dispatch input) — the guard can't tell which, so
-          # it refuses unless acknowledged. Compare parsed agency-id sets,
-          # not grepped text, so YAML formatting differences can't mask a
-          # removal.
-          removed=$(uv run python - <<'EOF'
+          # be dropped from production by this deploy — either out-of-band
+          # drift (must be reconciled into git) or an intentional removal PR
+          # (must be acknowledged via the allow_removals dispatch input); the
+          # guard can't tell which, so it refuses unless acknowledged.
+          uv run python - <<'EOF' > /tmp/drift.out
           import yaml
 
-          def ids(path):
-              data = yaml.safe_load(open(path)) or {}
-              return {a["id"] for a in data.get("agencies", [])}
+          deployed = yaml.safe_load(open("/tmp/deployed-agencies.yaml")) or {}
+          local = yaml.safe_load(open("agencies.yaml")) or {}
 
-          print(",".join(sorted(ids("/tmp/deployed-agencies.yaml") - ids("agencies.yaml"))))
+          print(f"changed={'true' if deployed != local else 'false'}")
+
+          deployed_ids = {a["id"] for a in deployed.get("agencies", [])}
+          local_ids = {a["id"] for a in local.get("agencies", [])}
+          print("removed=" + ",".join(sorted(deployed_ids - local_ids)))
           EOF
-          )
+          cat /tmp/drift.out >> "$GITHUB_OUTPUT"
+          changed=$(grep '^changed=' /tmp/drift.out | cut -d= -f2)
+          removed=$(grep '^removed=' /tmp/drift.out | cut -d= -f2-)
+
+          if [ "$changed" != "true" ]; then
+            echo "Deployed configuration is semantically identical; nothing to deploy."
+            exit 0
+          fi
+
           if [ -n "$removed" ]; then
             if [ "${{ inputs.allow_removals }}" = "true" ]; then
               echo "::notice::allow_removals acknowledged — this deploy removes: $removed"
@@ -147,11 +151,13 @@ jobs:
       - name: Restart archiver service
         if: steps.drift.outputs.changed == 'true'
         run: |
-          # Secret volumes are cached per revision; force a new revision
+          # Secret volumes are cached per revision; force a new revision.
+          # run_id-run_attempt is strictly monotonic, so no two runs can
+          # collide on the same value the way same-second timestamps could.
           gcloud run services update "$SERVICE_NAME" \
             --region="$GCP_REGION" \
             --project="$GCP_PROJECT_ID" \
-            --update-env-vars="DEPLOY_TIMESTAMP=$(date +%s)"
+            --update-env-vars="DEPLOY_TIMESTAMP=${{ github.run_id }}-${{ github.run_attempt }}"
 
       - name: Verify deployment
         if: steps.drift.outputs.changed == 'true'
@@ -162,33 +168,30 @@ jobs:
             --format='value(status.url)')
           echo "Service URL: $SERVICE_URL"
 
-          ready=false
-          for i in {1..30}; do
-            if curl -sf "${SERVICE_URL}/health" > /tmp/health.json 2>/dev/null; then
-              ready=true
-              break
-            fi
-            echo "Attempt $i/30: service not ready yet..."
-            sleep 10
-          done
-          if [ "$ready" != "true" ]; then
-            echo "::error::Service did not become ready within 5 minutes"
-            exit 1
-          fi
-
-          jq . /tmp/health.json
-          scheduled=$(jq -r .scheduler.jobs_scheduled /tmp/health.json)
           expected="${{ steps.validate.outputs.feeds }}"
 
+          # /health returns 200 as soon as the HTTP server is up, which is
+          # BEFORE the scheduler finishes adding jobs (and the Cloud Run
+          # startup probe is also /health, so traffic can arrive in that
+          # window). Readiness therefore means "scheduler reports the
+          # expected job count", not "first 200" — a low or missing count is
+          # treated as not-ready-yet and polled again.
           # NOTE: this equality assumes a single instance with TOTAL_SHARDS=1
           # (the current tf defaults). With sharding or >1 instance, each
           # instance schedules only its shard's subset of feeds and this
           # check would need to compare against the shard size instead.
-          if [ "$scheduled" != "$expected" ]; then
-            echo "::error::Scheduler has $scheduled jobs but the config defines $expected feeds"
-            exit 1
-          fi
-          echo "Healthy with $scheduled/$expected feeds scheduled."
+          scheduled=""
+          for i in {1..30}; do
+            scheduled=$(curl -sf "${SERVICE_URL}/health" | jq -r '.scheduler.jobs_scheduled // empty' 2>/dev/null || true)
+            if [ "$scheduled" = "$expected" ]; then
+              echo "Healthy with $scheduled/$expected feeds scheduled."
+              exit 0
+            fi
+            echo "Attempt $i/30: jobs_scheduled=${scheduled:-n/a}, want $expected..."
+            sleep 10
+          done
+          echo "::error::Scheduler did not reach $expected scheduled feeds within 5 minutes (last seen: ${scheduled:-n/a})"
+          exit 1
 
       - name: Report per-feed status
         if: steps.drift.outputs.changed == 'true'
@@ -204,16 +207,17 @@ jobs:
           # Individual feed failures don't fail the deploy — agency endpoints
           # can be legitimately down at any time; this is a visibility report.
           sleep 150
+          # Single snapshot so the table and the warning agree
+          curl -s "${SERVICE_URL}/health/feeds" > /tmp/feeds.json
           {
             echo "## Per-feed status (150s after restart)"
             echo ""
             echo "| Feed | Last success |"
             echo "| ---- | ------------ |"
-            curl -s "${SERVICE_URL}/health/feeds" | jq -r \
-              '.[] | "| \(.feed_id) | \(if .last_success_seconds_ago == null then "none yet ⚠️" else "\(.last_success_seconds_ago)s ago" end) |"'
+            jq -r '.[] | "| \(.feed_id) | \(if .last_success_seconds_ago == null then "none yet ⚠️" else "\(.last_success_seconds_ago)s ago" end) |"' /tmp/feeds.json
           } >> "$GITHUB_STEP_SUMMARY"
 
-          never=$(curl -s "${SERVICE_URL}/health/feeds" | jq -r '[.[] | select(.last_success_seconds_ago == null)] | length')
+          never=$(jq -r '[.[] | select(.last_success_seconds_ago == null)] | length' /tmp/feeds.json)
           if [ "$never" != "0" ]; then
             echo "::warning::$never feed(s) have not completed a successful fetch yet — check the summary table"
           fi

--- a/.github/workflows/deploy-agencies.yaml
+++ b/.github/workflows/deploy-agencies.yaml
@@ -5,6 +5,13 @@ on:
     branches: [develop]
     paths: [agencies.yaml]
   workflow_dispatch:
+    inputs:
+      allow_removals:
+        description: >-
+          Permit deploying a config that removes agencies currently in the
+          deployed secret (required to complete an intentional removal PR)
+        type: boolean
+        default: false
 
 # Serialize config deployments; never cancel one mid-flight
 concurrency:
@@ -94,19 +101,33 @@ jobs:
           fi
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
-          # Agencies present in the deployed secret but missing from git mean
-          # someone deployed directly without committing. Deploying now would
-          # silently remove them from production — fail so a human reconciles
-          # (commit the missing agency to git, or intentionally remove it in a
-          # PR, then re-run).
-          missing=$(comm -23 \
-            <(grep -E "^  - id:" /tmp/deployed-agencies.yaml | sort) \
-            <(grep -E "^  - id:" agencies.yaml | sort))
-          if [ -n "$missing" ]; then
-            echo "::error::Deployed secret contains agencies missing from agencies.yaml:"
-            echo "$missing"
-            echo "Reconcile them into git (or remove them intentionally via PR) before deploying."
-            exit 1
+          # Agencies present in the deployed secret but absent from git would
+          # be dropped from production by this deploy. That's either an
+          # out-of-band direct-to-secret deploy (must be reconciled into git)
+          # or an intentional removal PR (must be acknowledged via the
+          # allow_removals dispatch input) — the guard can't tell which, so
+          # it refuses unless acknowledged. Compare parsed agency-id sets,
+          # not grepped text, so YAML formatting differences can't mask a
+          # removal.
+          removed=$(uv run python - <<'EOF'
+          import yaml
+
+          def ids(path):
+              data = yaml.safe_load(open(path)) or {}
+              return {a["id"] for a in data.get("agencies", [])}
+
+          print(",".join(sorted(ids("/tmp/deployed-agencies.yaml") - ids("agencies.yaml"))))
+          EOF
+          )
+          if [ -n "$removed" ]; then
+            if [ "${{ inputs.allow_removals }}" = "true" ]; then
+              echo "::notice::allow_removals acknowledged — this deploy removes: $removed"
+            else
+              echo "::error::This deploy would remove agencies present in the deployed secret but not in agencies.yaml: $removed"
+              echo "If they were deployed out-of-band, commit them to git first (see .claude/commands/deploy-agencies.md)."
+              echo "If the removal is intentional, re-run via: gh workflow run deploy-agencies.yaml --ref develop -f allow_removals=true"
+              exit 1
+            fi
           fi
 
           {
@@ -141,23 +162,28 @@ jobs:
             --format='value(status.url)')
           echo "Service URL: $SERVICE_URL"
 
+          ready=false
           for i in {1..30}; do
             if curl -sf "${SERVICE_URL}/health" > /tmp/health.json 2>/dev/null; then
+              ready=true
               break
             fi
             echo "Attempt $i/30: service not ready yet..."
             sleep 10
           done
+          if [ "$ready" != "true" ]; then
+            echo "::error::Service did not become ready within 5 minutes"
+            exit 1
+          fi
 
           jq . /tmp/health.json
-          status=$(jq -r .status /tmp/health.json)
           scheduled=$(jq -r .scheduler.jobs_scheduled /tmp/health.json)
           expected="${{ steps.validate.outputs.feeds }}"
 
-          if [ "$status" != "healthy" ]; then
-            echo "::error::Service is not healthy after restart"
-            exit 1
-          fi
+          # NOTE: this equality assumes a single instance with TOTAL_SHARDS=1
+          # (the current tf defaults). With sharding or >1 instance, each
+          # instance schedules only its shard's subset of feeds and this
+          # check would need to compare against the shard size instead.
           if [ "$scheduled" != "$expected" ]; then
             echo "::error::Scheduler has $scheduled jobs but the config defines $expected feeds"
             exit 1
@@ -172,12 +198,14 @@ jobs:
             --project="$GCP_PROJECT_ID" \
             --format='value(status.url)')
 
-          # Give feeds one interval cycle to complete their first fetch.
+          # Wait past the slowest first fetch: service_alerts defaults to a
+          # 60s interval and feeds get a staggered start offset of up to one
+          # interval, so 150s covers 60s interval + 60s stagger + fetch time.
           # Individual feed failures don't fail the deploy — agency endpoints
           # can be legitimately down at any time; this is a visibility report.
-          sleep 75
+          sleep 150
           {
-            echo "## Per-feed status (75s after restart)"
+            echo "## Per-feed status (150s after restart)"
             echo ""
             echo "| Feed | Last success |"
             echo "| ---- | ------------ |"


### PR DESCRIPTION
Converts the `/deploy-agencies` skill workflow into CI. New workflow `.github/workflows/deploy-agencies.yaml`:

**Triggers:** push to `develop` touching `agencies.yaml` (i.e. merging an agency PR), plus `workflow_dispatch` for on-demand runs. Serialized via a `deploy-agencies` concurrency group.

**Pipeline:**
1. **Validate** — parse `agencies.yaml` through `AgenciesFileConfig` + `flatten_agencies()` (same models the archiver uses); fail on schema errors or duplicate agency IDs; capture the expected feed count
2. **Auth** — existing WIF setup (`github-actions-deploy` SA, same as deploy.yaml; it already has `run.admin` + Secret Manager admin, so **no new IAM needed**)
3. **Drift guard** — fetch the deployed secret and compare:
   - identical → skip everything (idempotent no-op)
   - deployed contains agencies missing from git → **fail with an error** instead of silently removing them from production (this is exactly how CATS was nearly lost — see #84; CI can't prompt Merge/Overwrite/Abort like the skill can, so it always aborts and demands reconciliation in git)
   - otherwise → post the config diff to the run summary and proceed
4. **Deploy** — new `agencies-config` secret version, then force a new Cloud Run revision via `DEPLOY_TIMESTAMP`
5. **Verify** — poll `/health` until healthy, assert `scheduler.jobs_scheduled` equals the validated feed count
6. **Report** — after one fetch cycle, post a per-feed `last_success` table to the run summary. Individual feed failures **warn but don't fail** the deploy — agency endpoints can be legitimately down at any moment, and a config deploy shouldn't be hostage to a third-party outage

Also updates the `/deploy-agencies` skill to document CI as the preferred path, keeping the manual workflow for emergencies, rollbacks, and interactive drift reconciliation, and touches the CLAUDE.md workflows comment.

**Draft because the trigger can't fire until this merges** — the push-path trigger only exists on `develop` once the workflow file is there. Suggested first test after merge: `gh workflow run deploy-agencies.yaml --ref develop` with the config unchanged, which should exercise auth + drift check and no-op cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)