### PR TITLE
feat(dagster): capture trip_modifications/shape/stop entities (#95 #96 #97)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -723,11 +723,22 @@ with repeated structures JSON-encoded instead.
 
 ### Assets
 
-| Asset | Description | Denormalization |
-| ------- | ------------- | ----------------- |
+| Asset | Description | Grain |
+| ------- | ------------- | ------- |
 | `vehicle_positions_parquet` | Vehicle positions for a day | One row per vehicle position update |
 | `trip_updates_parquet` | Trip updates for a day | One row per stop_time_update (or base record if none) |
 | `service_alerts_parquet` | Service alerts for a day | One row per informed_entity (or base record if none) |
+| `trip_modifications_parquet` | TripModifications (detour) entities for a day (#95) | One row per entity; repeated structures JSON-encoded |
+| `shapes_parquet` | Shape (detour geometry) entities for a day (#96) | One row per entity |
+| `stops_parquet` | Ad-hoc/replacement Stop entities for a day (#97) | One row per entity |
+
+`trip_updates_parquet`, `trip_modifications_parquet`, `shapes_parquet`, and
+`stops_parquet` are the four outputs of ONE non-subsettable `@multi_asset`:
+Madison Metro and Big Blue Bus publish trip_modifications/shape/stop entities
+inside their trip_updates feed URLs (2026-08-04 census), so all four tables
+are extracted from a single download+parse pass of the trip_updates raw
+files. Re-materializing the partition rewrites all four outputs (same source
+bytes); an output with zero records uploads nothing.
 
 ### Data Flow
 
@@ -775,8 +786,49 @@ Each feed type has a defined schema for consistent output:
 - Communication/impact periods: `communication_periods_json`, `impact_periods_json` (same encoding and NULL semantics as `active_periods_json`)
 - Header/entity: `feed_version`, `incrementality`, `is_deleted`
 
-Translated fields store the first translation only (typically English) — a
-deliberate keep-first decision (#91). All columns added by #91 (including the
+**Trip Modifications** (#95):
+
+- Base: `source_file`, `feed_url`, `feed_timestamp`, `fetch_timestamp`, `entity_id`
+- Payload: `selected_trips_json`, `start_times_json`, `service_dates_json`, `modifications_json`
+- Header/entity: `feed_version`, `incrementality`, `is_deleted`
+
+**Shapes** (#96):
+
+- Base: `source_file`, `feed_url`, `feed_timestamp`, `fetch_timestamp`, `entity_id`
+- Payload: `shape_id`, `encoded_polyline` (Google encoded polyline)
+- Header/entity: `feed_version`, `incrementality`, `is_deleted`
+
+**Stops** (#97):
+
+- Base: `source_file`, `feed_url`, `feed_timestamp`, `fetch_timestamp`, `entity_id`
+- Payload: `stop_id`, `stop_code_translations_json`, `stop_name_translations_json`, `tts_stop_name_translations_json`, `stop_desc_translations_json`, `stop_lat`, `stop_lon`, `zone_id`, `stop_url_translations_json`, `parent_station`, `stop_timezone`, `wheelchair_boarding`, `level_id`, `platform_code_translations_json`
+- Header/entity: `feed_version`, `incrementality`, `is_deleted`
+
+The three entity-grain tables (trip_modifications, shapes, stops — the
+TripModifications detour family, experimental in the spec) follow different
+conventions than the original three, deliberately (see the grain-decision
+entry above): one row per FeedEntity per snapshot, with every repeated
+structure JSON-encoded whole so unnesting is a downstream transform concern.
+JSON columns are NULL when the repeated field is empty (never `"[]"`), use
+per-field presence inside objects (unset → JSON null), and keep nested empty
+lists as `[]` (the parent exists, its list is empty). Join keys:
+`trip_modifications.entity_id` is what `modified_trip_modifications_id`
+(trip_updates/vehicle_positions rows) points at;
+`Modification.service_alert_id` inside `modifications_json` references
+service_alerts entity ids; `selected_trips.shape_id` and
+`trip_properties_shape_id` reference `shapes.shape_id`. The stops table's
+`*_translations_json` columns capture ALL translations as
+`[{"text": …, "language": …}, …]` in publisher order — full fidelity from
+day one, unlike the service_alerts keep-first columns (#98); any display
+selection rule is derivable downstream. Duplication is accepted by design:
+polylines and stop definitions repeat identically in every ~20s snapshot
+for a detour's lifetime (the VP/TU every-snapshot model; zstd + dictionary
+encoding collapse repeats on disk) — dedup at query time, e.g.
+`QUALIFY ROW_NUMBER() OVER (PARTITION BY shape_id ORDER BY feed_timestamp DESC) = 1`.
+
+Service_alerts translated fields store the first translation only (typically
+English) — a deliberate keep-first decision (#91; the stops table's
+`*_translations_json` columns are exempt, see above). All columns added by #91 (including the
 gtfs-realtime-bindings-2.2.0-gated `*_scheduled_time`, `cause_detail`,
 `effect_detail`, `image_url`, `modified_trip_*`) populate only from the
 release that shipped them onward; earlier partitions lack the columns and

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -703,6 +703,24 @@ The Dagster pipeline compacts raw protobuf archives into daily Parquet files for
 | **Streaming parquet writer** | Process feeds in batches to limit memory usage (vs. accumulating all records) |
 | **Denormalization** | Flatten nested GTFS-RT structures for SQL-friendly analytics |
 
+**On the denormalized grain (recorded 2026-08-05, retroactively):** the
+one-row-per-innermost-repeated-element grain (trip_updates rows are
+stop_time_updates, service_alerts rows are informed_entities) was set in the
+original compaction commit (e4a11e1) **without articulated rationale** — the
+alternative of one row per feed-entity message, with unnesting handled
+downstream in a transform layer, was never weighed. TripModifications
+entities existed in the spec at that time and were seemingly not
+supported or considered by the decision. The tradeoff that choice bought is
+now visible: a producer's single feed message splits across multiple tables
+(a TripUpdate's trip-level fields replicate across its STU rows, and the
+TripModifications family lands in separate tables), and table schemas are
+fixed at compaction time — where changes require re-materialization — rather
+than in a downstream transform layer (dbt) where changes are cheap. The
+grain is **retained as-is** for the original three tables because changing
+it now would be disruptive to every existing consumer and partition; tables
+added later (trip_modifications, shapes, stops) use the entity/message grain
+with repeated structures JSON-encoded instead.
+
 ### Assets
 
 | Asset | Description | Denormalization |

--- a/README.md
+++ b/README.md
@@ -305,6 +305,14 @@ The Dagster pipeline compacts raw protobuf archives into daily Parquet files for
 | `vehicle_positions_parquet` | Vehicle position records for a day |
 | `trip_updates_parquet` | Trip update records (denormalized by stop_time_update) |
 | `service_alerts_parquet` | Service alert records (denormalized by informed_entity) |
+| `trip_modifications_parquet` | TripModifications (detour) entities, one row per entity |
+| `shapes_parquet` | Shape (detour geometry) entities, one row per entity |
+| `stops_parquet` | Ad-hoc/replacement Stop entities, one row per entity |
+
+The last three ride the trip_updates parse: some agencies publish
+TripModifications/Shape/Stop entities inside their trip_updates feed URLs,
+so one `@multi_asset` extracts all four tables from a single pass over the
+raw files (materializing any of the four materializes all four).
 
 ### Schedule
 

--- a/dashboards/proto-parquet-reconciliation/extract.py
+++ b/dashboards/proto-parquet-reconciliation/extract.py
@@ -70,10 +70,13 @@ ENTITY_FIELDS = {
 HEADER_ONLY_MAX = 20
 
 # Ported from inventory.py's _RT_PATTERN so the two definitions of a valid RT
-# parquet path can't drift (this script can't import from src/).
+# parquet path can't drift (this script can't import from src/). The prefix
+# allowlist deliberately excludes the entity-grain tables (#95-#97): their
+# rows come from trip_updates protos and must not be reconciled against
+# trip_updates rows-per-proto expectations.
 _RT_PATTERN = re.compile(
-    r"^(?P<feed_type>[^/]+)/date=(?P<date>\d{4}-\d{2}-\d{2})"
-    r"/base64url=(?P<base64url>[A-Za-z0-9_-]+)/data\.parquet$"
+    r"^(?P<feed_type>vehicle_positions|trip_updates|service_alerts)"
+    r"/date=(?P<date>\d{4}-\d{2}-\d{2})/base64url=(?P<base64url>[A-Za-z0-9_-]+)/data\.parquet$"
 )
 
 # The reconcilable window, buffered at both edges (see the plan): older than

--- a/plans/entity-type-capture.md
+++ b/plans/entity-type-capture.md
@@ -1,0 +1,127 @@
+---
+status: in-progress
+depends: [rt-field-extraction]
+specs: []
+issues: [95, 96, 97]
+---
+
+# Entity-type capture: trip_modifications, shapes, stops
+
+Close the last parsing gap: the 2026-08-04 fleet census (PR #94) found Madison
+Metro and Big Blue Bus publishing `trip_modifications` (312), `shape` (316),
+and `stop` (90) entities inside their trip_updates feed URLs — fetched,
+archived to raw `.pb`, then silently dropped at compaction. Three new Parquet
+tables + BigQuery external tables capture them. Targets the v0.9.3 release as
+pass two behind PR #94 (branch stacked on `feat/rt-field-extraction`; user
+decision 2026-08-05: #94 is overburdened, this ships as its own PR, both merge
+before the release).
+
+## Scope
+
+- `schemas.py`: three new schemas — `trip_modifications`, `shapes`, `stops`
+- `compaction.py`: three extractors; `compact_single_feed` generalized to a
+  multi-table one-pass loop; the trip_updates asset becomes a `@multi_asset`
+  emitting four outputs from one parse of the same raw files (#95 recorded
+  decision — download+parse are the dominant costs and are already paid)
+- `REQUIRED_BINDINGS_FIELDS` guard entries for every new HasField surface
+  (FeedEntity.shape/stop/trip_modifications raise ValueError on pre-2.2
+  bindings — exactly the swallowed-into-`files_failed` class the guard exists
+  to catch at import instead)
+- Manifest test: the three `DROPPED_SUBTREES` entries are deleted; every leaf
+  of the three subtrees gets a capture disposition
+- `sensors.py` / `schedules.py`: TU config selects all four asset keys (a
+  non-subsettable multi_asset cannot be selected by one key)
+- `tf/bigquery.tf`: three external tables, order-locked to schemas.py (DDL
+  parity test extended)
+- DESIGN.md: new-table schema sections, grain rationale, duplication note,
+  join-key documentation; plus the separate grain-decision honesty entry
+  (user-directed, same PR)
+
+Out of scope: multi-language handling for service_alerts (#98 — but see the
+stops decision below); reconciliation-dashboard expectations for the new
+tables (local-only tooling, noted in Risks); historical backfill (#91 open
+question, unchanged).
+
+## Design decisions
+
+1. **Grain: one row per FeedEntity — the message grain.** Repeated structures
+   are JSON-encoded columns, unnesting happens downstream at query/transform
+   time. This deliberately does NOT extend the one-row-per-innermost-element
+   denormalization of the original three tables. That grain was set in
+   e4a11e1 without articulated rationale (see the DESIGN.md entry this plan
+   adds), and its cost is now visible: schema decisions frozen at compaction
+   where changes are expensive, vs a transform layer (dbt) where they are
+   cheap. New tables with no compatibility baggage get the conservative
+   shape: capture the message whole, derive downstream.
+   - `trip_modifications`: `selected_trips_json`, `start_times_json`,
+     `service_dates_json`, `modifications_json` (selectors, delays,
+     replacement_stops, service_alert_id, last_modified_time nested inside).
+     Join keys still work at this grain: `entity_id` is what
+     `modified_trip_modifications_id` (TU/VP rows) points at;
+     `service_alert_id` is reachable via JSON functions until a transform
+     layer unnests it.
+   - `shapes`: naturally entity-grain — `shape_id`, `encoded_polyline`.
+   - `stops`: scalars per-field-presence; six TranslatedString fields as
+     `*_translations_json` (below).
+2. **Stop TranslatedStrings: full-fidelity JSON from day one.**
+   `[{"text": …, "language": …}, …]` per field, column NULL when unset —
+   never `"[]"` (the `active_periods_json` conventions). #97 says the #98
+   decision should apply from day one; capturing everything is the
+   #98-neutral superset: no selection rule is baked in, any future keep-first
+   or prefer-English column is derivable downstream, and no migration can
+   ever be owed. The manifest records the `.translation.language` leaves
+   under stops as CAPTURED (unlike service_alerts' keep-first drops).
+3. **JSON conventions** (inherited from `active_periods_json` /
+   `_carriages_json`): column NULL when the repeated field is empty, never
+   `"[]"`; compact separators; per-field presence inside objects (unset →
+   JSON null); nested empty lists inside objects stay `[]` (honest: the
+   parent exists, its list is empty).
+4. **Every-snapshot duplication accepted** (#96/#97): polylines and stop
+   definitions repeat identically in every ~20s snapshot for a detour's
+   lifetime. Matches the VP/TU every-snapshot model; zstd + dictionary
+   encoding collapse repeats on disk; dedup belongs at query time
+   (`QUALIFY ROW_NUMBER() OVER (PARTITION BY shape_id ...)`), documented in
+   DESIGN.md.
+5. **One `@multi_asset`, four outputs, not subsettable.** Re-materializing a
+   partition rewrites all four outputs — correct, same source bytes. The
+   zero-records → no-upload path applies per output (29 of 31 TU feeds have
+   none of these entities; their shapes/stops/trip_modifications outputs
+   upload nothing). Parse failures count once into a shared `files_failed`
+   reported on every output; a conversion/write failure names file AND table
+   and fails the whole partition (all four outputs).
+6. **Output prefixes**: `trip_modifications/`, `shapes/`, `stops/` in the
+   parquet bucket, same `date=`/`base64url=` hive layout — read prefix stays
+   `trip_updates/` in the protobuf bucket.
+
+## Validation criteria
+
+- [ ] Manifest test passes with zero `DROPPED_SUBTREES` entity types — every
+      leaf of the three subtrees dispositioned to a real column
+- [ ] Extraction tests: populated fixtures (no NULLs, Arrow round-trip),
+      unset → NULL, JSON encodings exact, record↔schema key parity
+- [ ] compact tests: multi-output run writes four parquets from mixed-entity
+      feeds; zero-entity tables upload nothing; error contract (parse-skip /
+      dg.Failure naming file+table / close semantics) preserved
+- [ ] DDL parity test covers all six tables; targeted `tofu plan`
+      shows 3 creates, 0 destroys, no changes to existing tables
+- [ ] ruff + mypy strict + full pytest green
+- [ ] End-to-end against real Madison/BBB data: materialize one partition
+      locally, inspect all four outputs (also seeds the GCS prefixes so
+      external-table creation at deploy cannot hit an empty prefix)
+- [ ] DESIGN.md: grain-decision entry + new-table sections; README table list
+
+## Risks / unknowns
+
+- **BigQuery external-table creation over an empty GCS prefix** may fail at
+  deploy-time `tofu apply` (CUSTOM hive mode + explicit schema probably fine,
+  but unverified). Mitigation: the end-to-end validation step seeds real
+  parquet under all three prefixes before the release merges.
+- **Reconciliation dashboard** (local-only) counts rows per `.pb` for TU
+  feeds; TM/shape/stop rows come from the same protos and must not be
+  reconciled against TU expectations. Not release-blocking; noted for the
+  next dashboard run.
+- **Run-worker memory**: four streaming writers instead of one for TU
+  partitions. Buffers hold compressed bytes; Madison worst case is small
+  (hundreds of entities/snapshot). Watch item on #92, not a blocker.
+- The experimental spec status of these messages means a future bindings bump
+  can reshape them — the manifest test fails closed when that happens.

--- a/plans/entity-type-capture.md
+++ b/plans/entity-type-capture.md
@@ -95,27 +95,33 @@ question, unchanged).
 
 ## Validation criteria
 
-- [ ] Manifest test passes with zero `DROPPED_SUBTREES` entity types — every
+- [x] Manifest test passes with zero `DROPPED_SUBTREES` entity types — every
       leaf of the three subtrees dispositioned to a real column
-- [ ] Extraction tests: populated fixtures (no NULLs, Arrow round-trip),
+- [x] Extraction tests: populated fixtures (no NULLs, Arrow round-trip),
       unset → NULL, JSON encodings exact, record↔schema key parity
-- [ ] compact tests: multi-output run writes four parquets from mixed-entity
+- [x] compact tests: multi-output run writes four parquets from mixed-entity
       feeds; zero-entity tables upload nothing; error contract (parse-skip /
       dg.Failure naming file+table / close semantics) preserved
-- [ ] DDL parity test covers all six tables; targeted `tofu plan`
-      shows 3 creates, 0 destroys, no changes to existing tables
-- [ ] ruff + mypy strict + full pytest green
-- [ ] End-to-end against real Madison/BBB data: materialize one partition
-      locally, inspect all four outputs (also seeds the GCS prefixes so
-      external-table creation at deploy cannot hit an empty prefix)
-- [ ] DESIGN.md: grain-decision entry + new-table sections; README table list
+- [x] DDL parity test covers all six tables; targeted `tofu plan`
+      shows 3 creates, 0 destroys, no changes to existing tables (verified
+      2026-08-05)
+- [x] ruff + mypy strict + full pytest green (239 tests)
+- [x] End-to-end against real Madison/BBB data (2026-08-04 snapshots,
+      read-only): Madison 34 trip_modifications / 34 shapes / 11 stops per
+      snapshot, BBB 4/4/0; live service_alert_id join keys (`CWDetour-…`)
+      and multi-week service_dates captured; Arrow round-trip clean.
+      Producer quirk recorded: BBB publishes last_modified_time in
+      MILLISECONDS (1785797872000) — captured verbatim in JSON, consumers
+      beware
+- [x] DESIGN.md: grain-decision entry + new-table sections; README table list
 
 ## Risks / unknowns
 
-- **BigQuery external-table creation over an empty GCS prefix** may fail at
-  deploy-time `tofu apply` (CUSTOM hive mode + explicit schema probably fine,
-  but unverified). Mitigation: the end-to-end validation step seeds real
-  parquet under all three prefixes before the release merges.
+- ~~**BigQuery external-table creation over an empty GCS prefix** may fail at
+  deploy-time `tofu apply`.~~ **Disproven 2026-08-05**: a probe external
+  table with CUSTOM hive partitioning + explicit schema created cleanly over
+  the empty `trip_modifications/` prefix (0 objects) and was deleted; the
+  deploy-time apply cannot hit this. No pre-seeding needed.
 - **Reconciliation dashboard** (local-only) counts rows per `.pb` for TU
   feeds; TM/shape/stop rows come from the same protos and must not be
   reconciled against TU expectations. Not release-blocking; noted for the

--- a/src/dagster_pipeline/defs/__init__.py
+++ b/src/dagster_pipeline/defs/__init__.py
@@ -8,7 +8,7 @@ from dagster_pipeline.defs.assets import (
     bucket_inventory,
     feeds_metadata,
     service_alerts_parquet,
-    trip_updates_parquet,
+    trip_updates_tables,
     vehicle_positions_parquet,
 )
 from dagster_pipeline.defs.resources import GCSResource, SecretManagerResource
@@ -27,7 +27,7 @@ from dagster_pipeline.defs.sensors import feed_discovery_sensor
 defs = dg.Definitions(
     assets=[
         vehicle_positions_parquet,
-        trip_updates_parquet,
+        trip_updates_tables,
         service_alerts_parquet,
         feeds_metadata,
         bucket_inventory,

--- a/src/dagster_pipeline/defs/assets/__init__.py
+++ b/src/dagster_pipeline/defs/assets/__init__.py
@@ -2,7 +2,7 @@
 
 from dagster_pipeline.defs.assets.compaction import (
     service_alerts_parquet,
-    trip_updates_parquet,
+    trip_updates_tables,
     vehicle_positions_parquet,
 )
 from dagster_pipeline.defs.assets.feeds_metadata import feeds_metadata
@@ -14,7 +14,7 @@ from dagster_pipeline.defs.assets.schedule import (
 
 __all__ = [
     "vehicle_positions_parquet",
-    "trip_updates_parquet",
+    "trip_updates_tables",
     "service_alerts_parquet",
     "feeds_metadata",
     "bucket_inventory",

--- a/src/dagster_pipeline/defs/assets/compaction.py
+++ b/src/dagster_pipeline/defs/assets/compaction.py
@@ -843,7 +843,7 @@ def extract_trip_modifications(
     is a downstream transform concern (DESIGN.md grain-decision entry).
     entity_id is the join target of the trip_updates/vehicle_positions
     modified_trip_modifications_id columns."""
-    feed_timestamp = feed.header.timestamp if feed.header.timestamp else None
+    feed_timestamp = feed.header.timestamp if feed.header.HasField("timestamp") else None
     header_fields = _header_fields(feed)
 
     for entity in feed.entity:
@@ -876,7 +876,7 @@ def extract_shapes(
     """Extract shape entities (#96) — detour replacement geometry. One row
     per entity per snapshot; identical polylines repeat across a detour's
     lifetime, dedup belongs at query time."""
-    feed_timestamp = feed.header.timestamp if feed.header.timestamp else None
+    feed_timestamp = feed.header.timestamp if feed.header.HasField("timestamp") else None
     header_fields = _header_fields(feed)
 
     for entity in feed.entity:
@@ -910,7 +910,7 @@ def extract_stops(
     for detours, possibly absent from static GTFS. Per-field presence for
     scalars; the six TranslatedString fields are captured full-fidelity as
     translations JSON (no keep-first selection baked in — #98)."""
-    feed_timestamp = feed.header.timestamp if feed.header.timestamp else None
+    feed_timestamp = feed.header.timestamp if feed.header.HasField("timestamp") else None
     header_fields = _header_fields(feed)
 
     for entity in feed.entity:

--- a/src/dagster_pipeline/defs/assets/compaction.py
+++ b/src/dagster_pipeline/defs/assets/compaction.py
@@ -4,9 +4,9 @@ import base64
 import io
 import json
 import re
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator, Sequence
 from datetime import datetime
-from typing import Any
+from typing import Any, NamedTuple
 
 import dagster as dg
 import pyarrow as pa
@@ -17,6 +17,9 @@ from google.transit import gtfs_realtime_pb2
 
 from dagster_pipeline.defs.assets.schemas import (
     SERVICE_ALERTS_SCHEMA,
+    SHAPES_SCHEMA,
+    STOPS_SCHEMA,
+    TRIP_MODIFICATIONS_SCHEMA,
     TRIP_UPDATES_SCHEMA,
     VEHICLE_POSITIONS_SCHEMA,
 )
@@ -103,6 +106,45 @@ try:
         (gtfs_realtime_pb2.TranslatedImage.LocalizedImage, "media_type"),
         (gtfs_realtime_pb2.Alert, "image_alternative_text"),
         (gtfs_realtime_pb2.EntitySelector, "direction_id"),
+        # Entity-type capture (#95/#96/#97): FeedEntity.shape/stop/
+        # trip_modifications are absent from pre-2.2 bindings, so the
+        # entity.HasField dispatch itself would raise the swallowed
+        # ValueError this guard exists for.
+        (gtfs_realtime_pb2.FeedEntity, "shape"),
+        (gtfs_realtime_pb2.FeedEntity, "stop"),
+        (gtfs_realtime_pb2.FeedEntity, "trip_modifications"),
+        (gtfs_realtime_pb2.Shape, "shape_id"),
+        (gtfs_realtime_pb2.Shape, "encoded_polyline"),
+        (gtfs_realtime_pb2.Stop, "stop_id"),
+        (gtfs_realtime_pb2.Stop, "stop_code"),
+        (gtfs_realtime_pb2.Stop, "stop_name"),
+        (gtfs_realtime_pb2.Stop, "tts_stop_name"),
+        (gtfs_realtime_pb2.Stop, "stop_desc"),
+        (gtfs_realtime_pb2.Stop, "stop_lat"),
+        (gtfs_realtime_pb2.Stop, "stop_lon"),
+        (gtfs_realtime_pb2.Stop, "zone_id"),
+        (gtfs_realtime_pb2.Stop, "stop_url"),
+        (gtfs_realtime_pb2.Stop, "parent_station"),
+        (gtfs_realtime_pb2.Stop, "stop_timezone"),
+        (gtfs_realtime_pb2.Stop, "wheelchair_boarding"),
+        (gtfs_realtime_pb2.Stop, "level_id"),
+        (gtfs_realtime_pb2.Stop, "platform_code"),
+        (gtfs_realtime_pb2.TripModifications, "selected_trips"),
+        (gtfs_realtime_pb2.TripModifications, "start_times"),
+        (gtfs_realtime_pb2.TripModifications, "service_dates"),
+        (gtfs_realtime_pb2.TripModifications, "modifications"),
+        (gtfs_realtime_pb2.TripModifications.SelectedTrips, "trip_ids"),
+        (gtfs_realtime_pb2.TripModifications.SelectedTrips, "shape_id"),
+        (gtfs_realtime_pb2.TripModifications.Modification, "start_stop_selector"),
+        (gtfs_realtime_pb2.TripModifications.Modification, "end_stop_selector"),
+        (gtfs_realtime_pb2.TripModifications.Modification, "propagated_modification_delay"),
+        (gtfs_realtime_pb2.TripModifications.Modification, "replacement_stops"),
+        (gtfs_realtime_pb2.TripModifications.Modification, "service_alert_id"),
+        (gtfs_realtime_pb2.TripModifications.Modification, "last_modified_time"),
+        (gtfs_realtime_pb2.StopSelector, "stop_sequence"),
+        (gtfs_realtime_pb2.StopSelector, "stop_id"),
+        (gtfs_realtime_pb2.ReplacementStop, "travel_time_to_stop"),
+        (gtfs_realtime_pb2.ReplacementStop, "stop_id"),
     )
 except AttributeError as e:
     raise ImportError(
@@ -694,6 +736,218 @@ def _get_text(translated_string: gtfs_realtime_pb2.TranslatedString) -> str | No
     return None
 
 
+def _translations_json(translated_string: gtfs_realtime_pb2.TranslatedString) -> str | None:
+    """Full-fidelity TranslatedString capture: [{"text","language"},...];
+    NULL when there are no translations, never "[]". Unlike the
+    service_alerts keep-first columns, nothing is dropped (#98 — the stops
+    table ships complete from day one so no migration is ever owed)."""
+    if not translated_string.translation:
+        return None
+    return json.dumps(
+        [
+            {
+                "text": t.text,
+                "language": t.language if t.HasField("language") else None,
+            }
+            for t in translated_string.translation
+        ],
+        separators=(",", ":"),
+    )
+
+
+def _string_list_json(values: Any) -> str | None:
+    """JSON-encode a repeated string field; NULL when empty, never "[]"."""
+    if not values:
+        return None
+    return json.dumps(list(values), separators=(",", ":"))
+
+
+def _selected_trips_json(selected_trips: Any) -> str | None:
+    """JSON-encode repeated TripModifications.SelectedTrips; NULL when empty."""
+    if not selected_trips:
+        return None
+    return json.dumps(
+        [
+            {
+                "trip_ids": list(st.trip_ids),
+                "shape_id": st.shape_id if st.HasField("shape_id") else None,
+            }
+            for st in selected_trips
+        ],
+        separators=(",", ":"),
+    )
+
+
+def _stop_selector_obj(selector: gtfs_realtime_pb2.StopSelector) -> dict[str, Any]:
+    return {
+        "stop_sequence": selector.stop_sequence if selector.HasField("stop_sequence") else None,
+        "stop_id": selector.stop_id if selector.HasField("stop_id") else None,
+    }
+
+
+def _modifications_json(modifications: Any) -> str | None:
+    """JSON-encode repeated TripModifications.Modification; NULL when the
+    column-level list is empty. Per-field presence inside (unset -> JSON
+    null); nested empty replacement_stops stays [] — the parent exists, its
+    list is empty."""
+    if not modifications:
+        return None
+    return json.dumps(
+        [
+            {
+                "start_stop_selector": (
+                    _stop_selector_obj(m.start_stop_selector)
+                    if m.HasField("start_stop_selector")
+                    else None
+                ),
+                "end_stop_selector": (
+                    _stop_selector_obj(m.end_stop_selector)
+                    if m.HasField("end_stop_selector")
+                    else None
+                ),
+                "propagated_modification_delay": (
+                    m.propagated_modification_delay
+                    if m.HasField("propagated_modification_delay")
+                    else None
+                ),
+                "replacement_stops": [
+                    {
+                        "travel_time_to_stop": (
+                            rs.travel_time_to_stop if rs.HasField("travel_time_to_stop") else None
+                        ),
+                        "stop_id": rs.stop_id if rs.HasField("stop_id") else None,
+                    }
+                    for rs in m.replacement_stops
+                ],
+                "service_alert_id": (
+                    m.service_alert_id if m.HasField("service_alert_id") else None
+                ),
+                "last_modified_time": (
+                    m.last_modified_time if m.HasField("last_modified_time") else None
+                ),
+            }
+            for m in modifications
+        ],
+        separators=(",", ":"),
+    )
+
+
+def extract_trip_modifications(
+    feed: gtfs_realtime_pb2.FeedMessage,
+    source_file: str,
+    feed_url: str,
+    fetch_timestamp: datetime | None,
+) -> Iterator[dict[str, Any]]:
+    """Extract trip_modifications entities (#95). Entity/message grain —
+    one row per entity, repeated structures JSON-encoded whole; unnesting
+    is a downstream transform concern (DESIGN.md grain-decision entry).
+    entity_id is the join target of the trip_updates/vehicle_positions
+    modified_trip_modifications_id columns."""
+    feed_timestamp = feed.header.timestamp if feed.header.timestamp else None
+    header_fields = _header_fields(feed)
+
+    for entity in feed.entity:
+        if entity.HasField("trip_modifications"):
+            tm = entity.trip_modifications
+            yield {
+                # Source metadata
+                "source_file": source_file,
+                "feed_url": feed_url,
+                "feed_timestamp": feed_timestamp,
+                "fetch_timestamp": fetch_timestamp,
+                "entity_id": entity.id,
+                # TripModifications payload
+                "selected_trips_json": _selected_trips_json(tm.selected_trips),
+                "start_times_json": _string_list_json(tm.start_times),
+                "service_dates_json": _string_list_json(tm.service_dates),
+                "modifications_json": _modifications_json(tm.modifications),
+                # Header / entity-level fields (all tables)
+                **header_fields,
+                "is_deleted": entity.is_deleted if entity.HasField("is_deleted") else None,
+            }
+
+
+def extract_shapes(
+    feed: gtfs_realtime_pb2.FeedMessage,
+    source_file: str,
+    feed_url: str,
+    fetch_timestamp: datetime | None,
+) -> Iterator[dict[str, Any]]:
+    """Extract shape entities (#96) — detour replacement geometry. One row
+    per entity per snapshot; identical polylines repeat across a detour's
+    lifetime, dedup belongs at query time."""
+    feed_timestamp = feed.header.timestamp if feed.header.timestamp else None
+    header_fields = _header_fields(feed)
+
+    for entity in feed.entity:
+        if entity.HasField("shape"):
+            shape = entity.shape
+            yield {
+                # Source metadata
+                "source_file": source_file,
+                "feed_url": feed_url,
+                "feed_timestamp": feed_timestamp,
+                "fetch_timestamp": fetch_timestamp,
+                "entity_id": entity.id,
+                # Shape payload
+                "shape_id": shape.shape_id if shape.HasField("shape_id") else None,
+                "encoded_polyline": (
+                    shape.encoded_polyline if shape.HasField("encoded_polyline") else None
+                ),
+                # Header / entity-level fields (all tables)
+                **header_fields,
+                "is_deleted": entity.is_deleted if entity.HasField("is_deleted") else None,
+            }
+
+
+def extract_stops(
+    feed: gtfs_realtime_pb2.FeedMessage,
+    source_file: str,
+    feed_url: str,
+    fetch_timestamp: datetime | None,
+) -> Iterator[dict[str, Any]]:
+    """Extract stop entities (#97) — ad-hoc/replacement stop definitions
+    for detours, possibly absent from static GTFS. Per-field presence for
+    scalars; the six TranslatedString fields are captured full-fidelity as
+    translations JSON (no keep-first selection baked in — #98)."""
+    feed_timestamp = feed.header.timestamp if feed.header.timestamp else None
+    header_fields = _header_fields(feed)
+
+    for entity in feed.entity:
+        if entity.HasField("stop"):
+            stop = entity.stop
+            yield {
+                # Source metadata
+                "source_file": source_file,
+                "feed_url": feed_url,
+                "feed_timestamp": feed_timestamp,
+                "fetch_timestamp": fetch_timestamp,
+                "entity_id": entity.id,
+                # Stop payload (proto field order)
+                "stop_id": stop.stop_id if stop.HasField("stop_id") else None,
+                "stop_code_translations_json": _translations_json(stop.stop_code),
+                "stop_name_translations_json": _translations_json(stop.stop_name),
+                "tts_stop_name_translations_json": _translations_json(stop.tts_stop_name),
+                "stop_desc_translations_json": _translations_json(stop.stop_desc),
+                "stop_lat": stop.stop_lat if stop.HasField("stop_lat") else None,
+                "stop_lon": stop.stop_lon if stop.HasField("stop_lon") else None,
+                "zone_id": stop.zone_id if stop.HasField("zone_id") else None,
+                "stop_url_translations_json": _translations_json(stop.stop_url),
+                "parent_station": (
+                    stop.parent_station if stop.HasField("parent_station") else None
+                ),
+                "stop_timezone": stop.stop_timezone if stop.HasField("stop_timezone") else None,
+                "wheelchair_boarding": (
+                    stop.wheelchair_boarding if stop.HasField("wheelchair_boarding") else None
+                ),
+                "level_id": stop.level_id if stop.HasField("level_id") else None,
+                "platform_code_translations_json": _translations_json(stop.platform_code),
+                # Header / entity-level fields (all tables)
+                **header_fields,
+                "is_deleted": entity.is_deleted if entity.HasField("is_deleted") else None,
+            }
+
+
 def extract_service_alerts(
     feed: gtfs_realtime_pb2.FeedMessage,
     source_file: str,
@@ -871,31 +1125,54 @@ def extract_service_alerts(
                 yield record
 
 
-def compact_single_feed(
+class TableSpec(NamedTuple):
+    """One output table of a compaction pass.
+
+    table_name doubles as the destination prefix in the parquet bucket
+    (`{table_name}/date=.../base64url=.../data.parquet`); the READ prefix
+    in the protobuf bucket is the feed_type passed to compact_feed_tables —
+    the two differ for the tables extracted out of trip_updates raw files.
+    """
+
+    table_name: str
+    schema: pa.Schema
+    extractor: Callable[
+        [gtfs_realtime_pb2.FeedMessage, str, str, datetime | None],
+        Iterator[dict[str, Any]],
+    ]
+
+
+def compact_feed_tables(
     context: dg.AssetExecutionContext,
     gcs: GCSResource,
     feed_type: str,
-    schema: pa.Schema,
-    extractor: Any,
-) -> dg.Output[dict[str, int]]:
-    """Compact a single feed for a single date partition.
+    tables: Sequence[TableSpec],
+) -> dict[str, tuple[dict[str, int], dict[str, Any]]]:
+    """Compact one feed's raw .pb files for one date partition into one or
+    more Parquet tables, downloading and parsing each file exactly once.
 
     Args:
         context: Dagster asset execution context with MultiPartitionKey
         gcs: GCS resource
-        feed_type: Feed type (vehicle_positions, trip_updates, service_alerts)
-        schema: PyArrow schema for this feed type
-        extractor: Function to extract records from protobuf
+        feed_type: Raw-file prefix in the protobuf bucket
+            (vehicle_positions, trip_updates, service_alerts)
+        tables: Output tables; each extractor runs against every parsed
+            FeedMessage
 
     Returns:
-        Output with metadata about files processed and records written
+        {table_name: (output_value, metadata)} — files_processed and
+        files_failed are shared across tables (one parse per file),
+        records_written and output_path are per table. A table with zero
+        records uploads nothing and has no output_path.
 
     Raises:
         dg.Failure: on Parquet conversion/write failure, naming the
-            offending .pb file — the partition fails rather than shipping
-            short. Parse failures (DecodeError/ValueError) are per-file:
-            skipped with a warning, the rest of the partition still writes.
-            The contract is pinned by tests/dagster/test_compact_single_feed.py.
+            offending .pb file and table — the partition fails (all
+            tables) rather than shipping short. Parse failures
+            (DecodeError/ValueError) are per-file: skipped with a warning
+            for every table consistently, the rest of the partition still
+            writes. The contract is pinned by
+            tests/dagster/test_compact_single_feed.py.
     """
     # Extract partition dimensions
     partition_keys = context.partition_key.keys_by_dimension
@@ -915,17 +1192,20 @@ def compact_single_feed(
 
     if not pb_files:
         context.log.info(f"No data found for feed {feed_key} on {date}")
-        return dg.Output(
-            {"files_processed": 0, "records_written": 0, "files_failed": 0},
-            metadata={
-                "files_processed": 0,
-                "records_written": 0,
-                "files_failed": 0,
-                "date": date,
-                "feed": feed_key,
-                "feed_url": feed_url,
-            },
-        )
+        return {
+            spec.table_name: (
+                {"files_processed": 0, "records_written": 0, "files_failed": 0},
+                {
+                    "files_processed": 0,
+                    "records_written": 0,
+                    "files_failed": 0,
+                    "date": date,
+                    "feed": feed_key,
+                    "feed_url": feed_url,
+                },
+            )
+            for spec in tables
+        }
 
     context.log.info(f"Processing {len(pb_files)} files for feed {feed_key}")
 
@@ -933,10 +1213,9 @@ def compact_single_feed(
     protobuf_bucket = client.bucket(gcs.protobuf_bucket)
     parquet_bucket = client.bucket(gcs.parquet_bucket)
 
-    output_path = f"{feed_type}/date={date}/base64url={feed_url_encoded}/data.parquet"
-    buffer = io.BytesIO()
-    writer: pq.ParquetWriter | None = None
-    records_count = 0
+    buffers = {spec.table_name: io.BytesIO() for spec in tables}
+    writers: dict[str, pq.ParquetWriter | None] = {spec.table_name: None for spec in tables}
+    records_counts = {spec.table_name: 0 for spec in tables}
     files_failed = 0
     loop_completed = False
 
@@ -952,98 +1231,133 @@ def compact_single_feed(
             # Arrow conversion sits outside it because pyarrow.ArrowInvalid
             # subclasses ValueError — a schema/type bug caught here would
             # otherwise masquerade as "every file failed to parse" and let a
-            # successful run write an empty partition.
+            # successful run write an empty partition. ALL tables' extraction
+            # sits inside it so a failing file is skipped consistently for
+            # every output, keeping the tables' row provenance in step.
             try:
                 feed = parse_protobuf(content)
-                records = list(extractor(feed, pb_file, feed_url, fetch_timestamp))
+                extracted = {
+                    spec.table_name: list(spec.extractor(feed, pb_file, feed_url, fetch_timestamp))
+                    for spec in tables
+                }
             except (DecodeError, ValueError) as e:
                 context.log.warning(f"Failed to parse {pb_file}: {e}")
                 files_failed += 1
                 continue
-            if not records:
-                continue
 
-            # Write batch to parquet stream. Fail the partition with the
-            # offending file named — any error escaping here bare gives no
-            # clue which of ~thousands of .pb files produced it. Broad on
-            # purpose: from_pylist raises ArrowInvalid/ArrowTypeError (which
-            # straddle ValueError/TypeError) and bare TypeError/OverflowError
-            # depending on the conversion path; the intent is "fail the
-            # partition, loudly, naming the file", not enumerating classes.
-            try:
-                batch = pa.Table.from_pylist(records, schema=schema)
-                if writer is None:
-                    writer = pq.ParquetWriter(
-                        buffer, schema, compression="zstd", compression_level=9
-                    )
-                writer.write_table(batch)
-            except MemoryError:
-                # Not a schema bug — don't send the operator after one. The
-                # identified path is active_periods_json replication on a
-                # worst-case alert (see #92 watch item).
-                raise
-            except Exception as e:
-                raise dg.Failure(f"Parquet conversion/write failed for {pb_file}: {e}") from e
-            records_count += len(records)
+            # Write batches to the per-table parquet streams. Fail the
+            # partition with the offending file and table named — any error
+            # escaping here bare gives no clue which of ~thousands of .pb
+            # files produced it. Broad on purpose: from_pylist raises
+            # ArrowInvalid/ArrowTypeError (which straddle ValueError/
+            # TypeError) and bare TypeError/OverflowError depending on the
+            # conversion path; the intent is "fail the partition, loudly,
+            # naming the file", not enumerating classes.
+            for spec in tables:
+                records = extracted[spec.table_name]
+                if not records:
+                    continue
+                try:
+                    batch = pa.Table.from_pylist(records, schema=spec.schema)
+                    writer = writers[spec.table_name]
+                    if writer is None:
+                        writer = pq.ParquetWriter(
+                            buffers[spec.table_name],
+                            spec.schema,
+                            compression="zstd",
+                            compression_level=9,
+                        )
+                        writers[spec.table_name] = writer
+                    writer.write_table(batch)
+                except MemoryError:
+                    # Not a schema bug — don't send the operator after one.
+                    # The identified path is active_periods_json replication
+                    # on a worst-case alert (see #92 watch item).
+                    raise
+                except Exception as e:
+                    raise dg.Failure(
+                        f"Parquet conversion/write failed for {pb_file} ({spec.table_name}): {e}"
+                    ) from e
+                records_counts[spec.table_name] += len(records)
         loop_completed = True
     finally:
-        if writer is not None:
-            try:
-                writer.close()
-            except Exception as close_err:
-                # An exception raised in a finally REPLACES the in-flight
-                # one — a close() failure after a write_table failure would
-                # bury the dg.Failure naming the offending file. Swallow only
-                # when the loop did NOT complete (an exception is unwinding);
-                # a close failure on the success path must stay loud, or the
-                # buffer would be uploaded with a missing/partial footer.
-                # (A local flag, not sys.exc_info(): that reflects the whole
-                # handler stack, so a caller's except block would wrongly
-                # mute a success-path close error.)
-                if loop_completed:
-                    raise
+        # An exception raised in a finally REPLACES the in-flight one — a
+        # close() failure after a write_table failure would bury the
+        # dg.Failure naming the offending file. Close EVERY writer first
+        # (an unclosed ParquetWriter re-raises from __del__ during GC),
+        # collecting errors; then swallow them only when the loop did NOT
+        # complete (an exception is unwinding). A close failure on the
+        # success path must stay loud, or a buffer would be uploaded with a
+        # missing/partial footer. (A local flag, not sys.exc_info(): that
+        # reflects the whole handler stack, so a caller's except block
+        # would wrongly mute a success-path close error.)
+        close_errors: list[tuple[str, Exception]] = []
+        for table_name, table_writer in writers.items():
+            if table_writer is not None:
+                try:
+                    table_writer.close()
+                except Exception as close_err:
+                    close_errors.append((table_name, close_err))
+        if close_errors:
+            if loop_completed:
+                for table_name, err in close_errors[1:]:
+                    context.log.warning(
+                        f"ParquetWriter.close() also failed for {table_name}: {err}"
+                    )
+                raise close_errors[0][1]
+            for table_name, err in close_errors:
                 context.log.warning(
-                    f"ParquetWriter.close() failed after earlier error: {close_err}"
+                    f"ParquetWriter.close() failed for {table_name} after earlier error: {err}"
                 )
 
-    if writer is None:
-        context.log.info(f"No records extracted for feed {feed_key}")
-        return dg.Output(
-            {"files_processed": len(pb_files), "records_written": 0, "files_failed": files_failed},
-            metadata={
-                "files_processed": len(pb_files),
-                "records_written": 0,
-                "files_failed": files_failed,
-                "date": date,
-                "feed": feed_key,
-                "feed_url": feed_url,
-            },
-        )
-
-    # Upload parquet file
-    buffer.seek(0)
-
-    output_blob = parquet_bucket.blob(output_path)
-    output_blob.upload_from_file(buffer, content_type="application/octet-stream")
-
-    context.log.info(f"Wrote {records_count} records to gs://{gcs.parquet_bucket}/{output_path}")
-
-    return dg.Output(
-        {
+    # Upload per table; a table with zero records uploads nothing (any
+    # previously-materialized parquet for the partition is left in place —
+    # the existing zero-records convention, applied per output).
+    results: dict[str, tuple[dict[str, int], dict[str, Any]]] = {}
+    for spec in tables:
+        value = {
             "files_processed": len(pb_files),
-            "records_written": records_count,
+            "records_written": records_counts[spec.table_name],
             "files_failed": files_failed,
-        },
-        metadata={
-            "files_processed": len(pb_files),
-            "records_written": records_count,
-            "files_failed": files_failed,
+        }
+        metadata: dict[str, Any] = {
+            **value,
             "date": date,
             "feed": feed_key,
             "feed_url": feed_url,
-            "output_path": f"gs://{gcs.parquet_bucket}/{output_path}",
-        },
+        }
+        if writers[spec.table_name] is None:
+            context.log.info(f"No {spec.table_name} records extracted for feed {feed_key}")
+        else:
+            output_path = f"{spec.table_name}/date={date}/base64url={feed_url_encoded}/data.parquet"
+            buffer = buffers[spec.table_name]
+            buffer.seek(0)
+            output_blob = parquet_bucket.blob(output_path)
+            output_blob.upload_from_file(buffer, content_type="application/octet-stream")
+            context.log.info(
+                f"Wrote {records_counts[spec.table_name]} records "
+                f"to gs://{gcs.parquet_bucket}/{output_path}"
+            )
+            metadata["output_path"] = f"gs://{gcs.parquet_bucket}/{output_path}"
+        results[spec.table_name] = (value, metadata)
+    return results
+
+
+def compact_single_feed(
+    context: dg.AssetExecutionContext,
+    gcs: GCSResource,
+    feed_type: str,
+    schema: pa.Schema,
+    extractor: Any,
+) -> dg.Output[dict[str, int]]:
+    """Compact a single feed into a single table for one date partition —
+    a one-table wrapper over compact_feed_tables (which carries the
+    error contract)."""
+    results = compact_feed_tables(
+        context, gcs, feed_type, (TableSpec(feed_type, schema, extractor),)
     )
+    value, metadata = results[feed_type]
+    return dg.Output(value, metadata=metadata)
 
 
 @dg.asset(
@@ -1066,24 +1380,60 @@ def vehicle_positions_parquet(
     )
 
 
-@dg.asset(
+# Tables produced from ONE parse of the trip_updates raw files. Madison
+# Metro and Big Blue Bus publish trip_modifications/shape/stop entities
+# inside their trip_updates feed URLs (2026-08-04 census; #95/#96/#97);
+# download + parse are the dominant costs and are already paid, so all four
+# tables are extracted in a single pass rather than re-reading ~thousands
+# of .pb files per additional table.
+TRIP_UPDATES_TABLES: tuple[TableSpec, ...] = (
+    TableSpec("trip_updates", TRIP_UPDATES_SCHEMA, extract_trip_updates),
+    TableSpec("trip_modifications", TRIP_MODIFICATIONS_SCHEMA, extract_trip_modifications),
+    TableSpec("shapes", SHAPES_SCHEMA, extract_shapes),
+    TableSpec("stops", STOPS_SCHEMA, extract_stops),
+)
+
+
+@dg.multi_asset(
     partitions_def=trip_updates_partitions,
     compute_kind="pyarrow",
     group_name="compaction",
-    description="Compacted trip updates data in Parquet format",
+    outs={
+        "trip_updates_parquet": dg.AssetOut(
+            description="Compacted trip updates data in Parquet format",
+        ),
+        "trip_modifications_parquet": dg.AssetOut(
+            description=(
+                "TripModifications (detour) entities published inside "
+                "trip_updates feeds, in Parquet format (#95)"
+            ),
+        ),
+        "shapes_parquet": dg.AssetOut(
+            description=(
+                "Shape (detour geometry) entities published inside "
+                "trip_updates feeds, in Parquet format (#96)"
+            ),
+        ),
+        "stops_parquet": dg.AssetOut(
+            description=(
+                "Ad-hoc/replacement Stop entities published inside "
+                "trip_updates feeds, in Parquet format (#97)"
+            ),
+        ),
+    },
 )
-def trip_updates_parquet(
+def trip_updates_tables(
     context: dg.AssetExecutionContext,
     gcs: GCSResource,
-) -> dg.Output[dict[str, int]]:
-    """Compact trip updates protobuf files into Parquet for a given date and feed."""
-    return compact_single_feed(
-        context,
-        gcs,
-        "trip_updates",
-        TRIP_UPDATES_SCHEMA,
-        extract_trip_updates,
-    )
+) -> Iterator[dg.Output[dict[str, int]]]:
+    """Compact trip updates protobuf files into four Parquet tables for a
+    given date and feed — one download/parse pass, one output per table.
+    Not subsettable: re-materializing the partition rewrites all four
+    outputs (correct — same source bytes)."""
+    results = compact_feed_tables(context, gcs, "trip_updates", TRIP_UPDATES_TABLES)
+    for spec in TRIP_UPDATES_TABLES:
+        value, metadata = results[spec.table_name]
+        yield dg.Output(value, output_name=f"{spec.table_name}_parquet", metadata=metadata)
 
 
 @dg.asset(

--- a/src/dagster_pipeline/defs/assets/compaction.py
+++ b/src/dagster_pipeline/defs/assets/compaction.py
@@ -1171,7 +1171,9 @@ def compact_feed_tables(
             tables) rather than shipping short. Parse failures
             (DecodeError/ValueError) are per-file: skipped with a warning
             for every table consistently, the rest of the partition still
-            writes. The contract is pinned by
+            writes — UNLESS every file failed, which is systemic and
+            fails the partition rather than reporting a green
+            zero-record run. The contract is pinned by
             tests/dagster/test_compact_single_feed.py.
     """
     # Extract partition dimensions
@@ -1309,6 +1311,19 @@ def compact_feed_tables(
                 context.log.warning(
                     f"ParquetWriter.close() failed for {table_name} after earlier error: {err}"
                 )
+
+    # EVERY file failing to parse is not per-file flakiness — it's systemic
+    # (garbage feed content archived all day, or a parser regression the
+    # import guard didn't cover) and a green zero-record run would hide it
+    # behind metadata nobody is forced to read. Partial failure stays
+    # per-file (skip + files_failed); total failure fails the partition.
+    # (PR #94 round 13.)
+    if files_failed == len(pb_files):
+        raise dg.Failure(
+            f"All {len(pb_files)} .pb files failed to parse for {feed_type} "
+            f"feed {feed_key} on {date} — systemic failure, refusing to "
+            f"report a successful zero-record run"
+        )
 
     # Upload per table; a table with zero records uploads nothing (any
     # previously-materialized parquet for the partition is left in place —

--- a/src/dagster_pipeline/defs/assets/inventory.py
+++ b/src/dagster_pipeline/defs/assets/inventory.py
@@ -21,9 +21,16 @@ class BucketScanResult:
         self.schedule_metadata: list[dict[str, str]] = []  # [{path, base64url, feed_digest}]
 
 
-# RT pattern: {feed_type}/date={YYYY-MM-DD}/base64url={encoded}/data.parquet
+# RT pattern: {feed_type}/date={YYYY-MM-DD}/base64url={encoded}/data.parquet.
+# Feed-type prefixes are an explicit allowlist of the PRIMARY per-feed
+# tables: the inventory aggregates by base64url alone, and the entity-grain
+# tables (trip_modifications/shapes/stops, #95-#97) share base64urls with
+# trip_updates feeds — an open [^/]+ match would silently sum their rows
+# into the feeds' trip_updates counts. Surfacing the derived tables in the
+# inventory is follow-up work, not an accident of the scan regex.
 _RT_PATTERN = re.compile(
-    r"^(?P<feed_type>[^/]+)/date=(?P<date>\d{4}-\d{2}-\d{2})/base64url=(?P<base64url>[A-Za-z0-9_-]+)/data\.parquet$"
+    r"^(?P<feed_type>vehicle_positions|trip_updates|service_alerts)"
+    r"/date=(?P<date>\d{4}-\d{2}-\d{2})/base64url=(?P<base64url>[A-Za-z0-9_-]+)/data\.parquet$"
 )
 
 # Schedule pattern: schedules/base64url={encoded}/_feed_digest={hash}/metadata.json

--- a/src/dagster_pipeline/defs/assets/schemas.py
+++ b/src/dagster_pipeline/defs/assets/schemas.py
@@ -125,6 +125,94 @@ TRIP_UPDATES_SCHEMA = pa.schema(
     ]
 )
 
+# Trip Modifications Schema (#95)
+# Entity/message grain: one row per trip_modifications entity per snapshot.
+# Repeated structures are JSON-encoded whole — unnesting is a downstream
+# transform concern (see the DESIGN.md grain-decision entry). entity_id is
+# the join target of trip_updates/vehicle_positions
+# modified_trip_modifications_id; Modification.service_alert_id (inside
+# modifications_json) points into service_alerts.
+TRIP_MODIFICATIONS_SCHEMA = pa.schema(
+    [
+        # Source metadata
+        pa.field("source_file", pa.string(), nullable=False),
+        pa.field("feed_url", pa.string(), nullable=False),
+        pa.field("feed_timestamp", pa.uint64()),
+        pa.field("fetch_timestamp", pa.timestamp("us", tz="UTC")),
+        pa.field("entity_id", pa.string(), nullable=False),
+        # TripModifications payload, JSON-encoded per repeated field
+        # (NULL when empty, never "[]")
+        pa.field("selected_trips_json", pa.string()),
+        pa.field("start_times_json", pa.string()),
+        pa.field("service_dates_json", pa.string()),
+        pa.field("modifications_json", pa.string()),
+        # Header / entity-level (all tables)
+        pa.field("feed_version", pa.string()),
+        pa.field("incrementality", pa.int32()),
+        pa.field("is_deleted", pa.bool_()),
+    ]
+)
+
+# Shapes Schema (#96)
+# One row per shape entity per snapshot — detour replacement geometry
+# referenced by TripModifications.selected_trips.shape_id and
+# trip_updates.trip_properties_shape_id. Polylines repeat identically
+# across snapshots for a detour's lifetime; dedup at query time.
+SHAPES_SCHEMA = pa.schema(
+    [
+        # Source metadata
+        pa.field("source_file", pa.string(), nullable=False),
+        pa.field("feed_url", pa.string(), nullable=False),
+        pa.field("feed_timestamp", pa.uint64()),
+        pa.field("fetch_timestamp", pa.timestamp("us", tz="UTC")),
+        pa.field("entity_id", pa.string(), nullable=False),
+        # Shape payload
+        pa.field("shape_id", pa.string()),
+        pa.field("encoded_polyline", pa.string()),
+        # Header / entity-level (all tables)
+        pa.field("feed_version", pa.string()),
+        pa.field("incrementality", pa.int32()),
+        pa.field("is_deleted", pa.bool_()),
+    ]
+)
+
+# Stops Schema (#97)
+# One row per stop entity per snapshot — ad-hoc/replacement stop
+# definitions for detours (may exist nowhere in static GTFS). The six
+# TranslatedString fields are captured full-fidelity as
+# [{"text": ..., "language": ...}, ...] JSON from day one (#98-neutral:
+# no keep-first selection rule is baked in; display text is derivable
+# downstream).
+STOPS_SCHEMA = pa.schema(
+    [
+        # Source metadata
+        pa.field("source_file", pa.string(), nullable=False),
+        pa.field("feed_url", pa.string(), nullable=False),
+        pa.field("feed_timestamp", pa.uint64()),
+        pa.field("fetch_timestamp", pa.timestamp("us", tz="UTC")),
+        pa.field("entity_id", pa.string(), nullable=False),
+        # Stop payload (proto field order)
+        pa.field("stop_id", pa.string()),
+        pa.field("stop_code_translations_json", pa.string()),
+        pa.field("stop_name_translations_json", pa.string()),
+        pa.field("tts_stop_name_translations_json", pa.string()),
+        pa.field("stop_desc_translations_json", pa.string()),
+        pa.field("stop_lat", pa.float32()),
+        pa.field("stop_lon", pa.float32()),
+        pa.field("zone_id", pa.string()),
+        pa.field("stop_url_translations_json", pa.string()),
+        pa.field("parent_station", pa.string()),
+        pa.field("stop_timezone", pa.string()),
+        pa.field("wheelchair_boarding", pa.int32()),
+        pa.field("level_id", pa.string()),
+        pa.field("platform_code_translations_json", pa.string()),
+        # Header / entity-level (all tables)
+        pa.field("feed_version", pa.string()),
+        pa.field("incrementality", pa.int32()),
+        pa.field("is_deleted", pa.bool_()),
+    ]
+)
+
 # Service Alerts Schema
 # Denormalized: one row per informed_entity within each alert
 SERVICE_ALERTS_SCHEMA = pa.schema(

--- a/src/dagster_pipeline/defs/schedules.py
+++ b/src/dagster_pipeline/defs/schedules.py
@@ -10,7 +10,7 @@ from dagster_pipeline.defs.assets import (
     gtfs_schedule_check,
     gtfs_schedule_ingest,
     service_alerts_parquet,
-    trip_updates_parquet,
+    trip_updates_tables,
     vehicle_positions_parquet,
 )
 from dagster_pipeline.defs.assets.schedule import schedule_feed_partitions
@@ -36,7 +36,7 @@ FEED_TYPE_CONFIGS = [
         "trip_updates",
         "trip_updates_feeds",
         trip_updates_feeds,
-        trip_updates_parquet,
+        trip_updates_tables,
     ),
     FeedTypeConfig(
         "service_alerts",
@@ -53,9 +53,10 @@ vehicle_positions_compaction_job = dg.define_asset_job(
     partitions_def=vehicle_positions_partitions,
 )
 
+# Selects the whole multi_asset (all four tables) — it is not subsettable
 trip_updates_compaction_job = dg.define_asset_job(
     name="trip_updates_compaction_job",
-    selection=[trip_updates_parquet],
+    selection=[trip_updates_tables],
     partitions_def=trip_updates_partitions,
 )
 

--- a/src/dagster_pipeline/defs/sensors.py
+++ b/src/dagster_pipeline/defs/sensors.py
@@ -7,7 +7,7 @@ import dagster as dg
 
 from dagster_pipeline.defs.assets import (
     service_alerts_parquet,
-    trip_updates_parquet,
+    trip_updates_tables,
     vehicle_positions_parquet,
 )
 from dagster_pipeline.defs.assets.compaction import (
@@ -29,6 +29,8 @@ class FeedTypeConfig(NamedTuple):
     feed_type: str  # GCS path component
     partition_name: str  # Name of the dynamic partition definition
     partition_def: dg.DynamicPartitionsDefinition  # For building add requests
+    # May carry multiple asset keys (trip_updates is a non-subsettable
+    # multi_asset) — select ALL of a config's keys, never a single .key
     asset: dg.AssetsDefinition
 
 
@@ -44,7 +46,7 @@ FEED_TYPE_CONFIGS = [
         "trip_updates",
         "trip_updates_feeds",
         trip_updates_feeds,
-        trip_updates_parquet,
+        trip_updates_tables,
     ),
     FeedTypeConfig(
         "service_alerts",
@@ -58,7 +60,7 @@ FEED_TYPE_CONFIGS = [
 @dg.sensor(
     asset_selection=[
         vehicle_positions_parquet,
-        trip_updates_parquet,
+        trip_updates_tables,
         service_alerts_parquet,
     ],
     minimum_interval_seconds=300,  # 5 minutes
@@ -121,7 +123,7 @@ def feed_discovery_sensor(
             run_requests.append(
                 dg.RunRequest(
                     run_key=f"{config.feed_type}_{yesterday}_{feed_key}",
-                    asset_selection=[config.asset.key],
+                    asset_selection=list(config.asset.keys),
                     partition_key=multi_key,
                 )
             )

--- a/tests/dagster/test_compact_single_feed.py
+++ b/tests/dagster/test_compact_single_feed.py
@@ -106,6 +106,22 @@ def test_decode_error_file_skipped_rest_of_partition_written(
     assert metadata.num_row_groups == 2  # one per non-empty .pb
 
 
+def test_all_files_failed_parse_fails_partition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every file failing to parse is systemic (garbage feed content or a
+    parser regression), not per-file flakiness: the partition must raise
+    dg.Failure instead of reporting a green zero-record run whose only
+    trace is metadata (PR #94 round 13). Partial failure staying per-file
+    is pinned by test_decode_error_file_skipped_rest_of_partition_written."""
+    store = {"bad1.pb": b"\x08", "bad2.pb": b"\xff\xff"}
+
+    with pytest.raises(dg.Failure, match=r"All 2 \.pb files failed to parse"):
+        _run(monkeypatch, store, ["bad1.pb", "bad2.pb"], compaction.extract_vehicle_positions)
+
+    assert not [k for k in store if k.endswith("data.parquet")]
+
+
 def test_conversion_failure_fails_partition_naming_file(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/dagster/test_compact_single_feed.py
+++ b/tests/dagster/test_compact_single_feed.py
@@ -155,6 +155,192 @@ def test_close_failure_on_success_path_propagates_and_blocks_upload(
     assert not [k for k in store if k.endswith("data.parquet")]
 
 
+def _mixed_tu_feed_bytes() -> bytes:
+    """A trip_updates snapshot carrying all four captured entity types —
+    the Madison/BBB shape (2026-08-04 census)."""
+    feed = gtfs_realtime_pb2.FeedMessage()
+    feed.header.gtfs_realtime_version = "2.0"
+    feed.header.timestamp = 1_754_000_000
+    e = feed.entity.add()
+    e.id = "tu-1"
+    e.trip_update.trip.trip_id = "trip-1"
+    e.trip_update.stop_time_update.add().stop_id = "s1"
+    e = feed.entity.add()
+    e.id = "tm-1"
+    st = e.trip_modifications.selected_trips.add()
+    st.trip_ids.append("trip-1")
+    st.shape_id = "shape-1"
+    e = feed.entity.add()
+    e.id = "shape-1"
+    e.shape.shape_id = "shape-1"
+    e.shape.encoded_polyline = "abc"
+    e = feed.entity.add()
+    e.id = "stop-1"
+    e.stop.stop_id = "st-1"
+    return feed.SerializeToString()
+
+
+def _tu_only_feed_bytes(entity_id: str) -> bytes:
+    feed = gtfs_realtime_pb2.FeedMessage()
+    feed.header.gtfs_realtime_version = "2.0"
+    feed.header.timestamp = 1_754_000_000
+    e = feed.entity.add()
+    e.id = entity_id
+    e.trip_update.trip.trip_id = "trip-x"
+    e.trip_update.stop_time_update.add().stop_id = "s1"
+    return feed.SerializeToString()
+
+
+def _run_tables(
+    monkeypatch: pytest.MonkeyPatch,
+    store: dict[str, bytes],
+    pb_files: list[str],
+) -> dict[str, tuple[dict[str, int], dict[str, Any]]]:
+    monkeypatch.setattr(compaction, "list_pb_files", lambda *_a, **_k: pb_files)
+    monkeypatch.setattr(GCSResource, "get_client", lambda _self: _FakeClient(store))
+    gcs = GCSResource(protobuf_bucket="pb-bucket", parquet_bucket="pq-bucket")
+    context = dg.build_asset_context(partition_key=PARTITION)
+    return compaction.compact_feed_tables(
+        context, gcs, "trip_updates", compaction.TRIP_UPDATES_TABLES
+    )
+
+
+def test_multi_table_pass_writes_each_populated_table_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One parse pass over mixed-entity trip_updates files must upload one
+    parquet per populated table under that table's own prefix, with shared
+    files_processed/files_failed and per-table records_written."""
+    store = {
+        "f1.pb": _mixed_tu_feed_bytes(),
+        "f2.pb": _tu_only_feed_bytes("tu-2"),
+    }
+    results = _run_tables(monkeypatch, store, ["f1.pb", "f2.pb"])
+
+    assert results["trip_updates"][0] == {
+        "files_processed": 2,
+        "records_written": 2,
+        "files_failed": 0,
+    }
+    for table in ("trip_modifications", "shapes", "stops"):
+        assert results[table][0] == {
+            "files_processed": 2,
+            "records_written": 1,
+            "files_failed": 0,
+        }
+
+    uploaded = sorted(k for k in store if k.endswith("data.parquet"))
+    assert uploaded == [
+        f"{table}/date=2026-07-01/base64url={compaction.encode_base64url('https://example.com/feed')}/data.parquet"
+        for table in sorted(("trip_updates", "trip_modifications", "shapes", "stops"))
+    ]
+    tu_table = pq.read_table(
+        io.BytesIO(store[[k for k in uploaded if k.startswith("trip_updates/")][0]])
+    )
+    assert tu_table.column("entity_id").to_pylist() == ["tu-1", "tu-2"]
+
+
+def test_multi_table_zero_record_tables_upload_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 29-of-31 case: a TU feed with no shape/stop/trip_modifications
+    entities uploads ONLY the trip_updates parquet; the other outputs
+    report zero records and carry no output_path."""
+    store = {"f1.pb": _tu_only_feed_bytes("tu-1")}
+    results = _run_tables(monkeypatch, store, ["f1.pb"])
+
+    uploaded = [k for k in store if k.endswith("data.parquet")]
+    assert len(uploaded) == 1
+    assert uploaded[0].startswith("trip_updates/")
+    for table in ("trip_modifications", "shapes", "stops"):
+        value, metadata = results[table]
+        assert value["records_written"] == 0
+        assert "output_path" not in metadata
+
+
+def test_parse_failure_skips_file_for_every_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A file that fails parsing is skipped consistently across all
+    outputs: files_failed reported on every table, no partial rows from
+    the bad file anywhere."""
+    store = {
+        "f1.pb": _mixed_tu_feed_bytes(),
+        "bad.pb": b"\x08",  # truncated varint -> DecodeError
+    }
+    results = _run_tables(monkeypatch, store, ["f1.pb", "bad.pb"])
+
+    for table in ("trip_updates", "trip_modifications", "shapes", "stops"):
+        value, _metadata = results[table]
+        assert value["files_failed"] == 1, table
+        assert value["files_processed"] == 2, table
+        assert value["records_written"] == 1, table
+
+
+def test_multi_table_conversion_failure_names_file_and_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A conversion failure in ANY table's records fails the whole
+    partition, naming the offending file and table, and nothing is
+    uploaded for any table."""
+    store = {"f1.pb": _mixed_tu_feed_bytes()}
+
+    def bad_extractor(_feed: Any, source_file: str, feed_url: str, _ts: Any) -> Any:
+        yield {
+            "source_file": source_file,
+            "feed_url": feed_url,
+            "entity_id": "x",
+            "latitude": "not-a-float",
+        }
+
+    specs = (
+        compaction.TableSpec(
+            "vehicle_positions", VEHICLE_POSITIONS_SCHEMA, compaction.extract_vehicle_positions
+        ),
+        compaction.TableSpec("poison_table", VEHICLE_POSITIONS_SCHEMA, bad_extractor),
+    )
+    monkeypatch.setattr(compaction, "list_pb_files", lambda *_a, **_k: ["f1.pb"])
+    monkeypatch.setattr(GCSResource, "get_client", lambda _self: _FakeClient(store))
+    gcs = GCSResource(protobuf_bucket="pb-bucket", parquet_bucket="pq-bucket")
+    context = dg.build_asset_context(partition_key=PARTITION)
+
+    with pytest.raises(dg.Failure, match=r"f1\.pb \(poison_table\)"):
+        compaction.compact_feed_tables(context, gcs, "trip_updates", specs)
+
+    assert not [k for k in store if k.endswith("data.parquet")]
+
+
+def test_trip_updates_tables_asset_emits_all_four_outputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The @multi_asset wiring end-to-end: materializing the trip_updates
+    partition yields all four outputs with per-table metadata."""
+    store = {"f1.pb": _mixed_tu_feed_bytes()}
+    monkeypatch.setattr(compaction, "list_pb_files", lambda *_a, **_k: ["f1.pb"])
+    monkeypatch.setattr(GCSResource, "get_client", lambda _self: _FakeClient(store))
+
+    with dg.instance_for_test() as instance:
+        instance.add_dynamic_partitions("trip_updates_feeds", ["example.com/feed"])
+        result = dg.materialize(
+            [compaction.trip_updates_tables],
+            partition_key=PARTITION,
+            resources={"gcs": GCSResource(protobuf_bucket="pb-bucket", parquet_bucket="pq-bucket")},
+            instance=instance,
+        )
+
+    assert result.success
+    for output_name in (
+        "trip_updates_parquet",
+        "trip_modifications_parquet",
+        "shapes_parquet",
+        "stops_parquet",
+    ):
+        value = result.output_for_node("trip_updates_tables", output_name)
+        assert value["files_processed"] == 1, output_name
+        assert value["records_written"] == 1, output_name
+    assert len([k for k in store if k.endswith("data.parquet")]) == 4
+
+
 def test_close_failure_does_not_bury_in_flight_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/dagster/test_entity_type_extraction.py
+++ b/tests/dagster/test_entity_type_extraction.py
@@ -1,0 +1,195 @@
+"""Behavior tests for the entity-type extractors (#95/#96/#97).
+
+Covers: exact JSON encodings at the entity/message grain, NULL (never "[]")
+for empty repeated fields, per-field presence inside JSON objects,
+full-fidelity multi-language TranslatedString capture (#98), and each
+extractor selecting only its own entity type from a mixed feed.
+"""
+
+import json
+
+from google.transit import gtfs_realtime_pb2
+
+from dagster_pipeline.defs.assets.compaction import (
+    extract_service_alerts,
+    extract_shapes,
+    extract_stops,
+    extract_trip_modifications,
+    extract_trip_updates,
+    extract_vehicle_positions,
+)
+
+
+def _feed() -> gtfs_realtime_pb2.FeedMessage:
+    feed = gtfs_realtime_pb2.FeedMessage()
+    feed.header.gtfs_realtime_version = "2.0"
+    feed.header.timestamp = 1_754_000_000
+    return feed
+
+
+def test_trip_modifications_json_encodings_exact() -> None:
+    """The four JSON columns must decode to the message's exact structure —
+    per-field presence inside objects (unset -> JSON null), nested empty
+    replacement_stops as [] (the parent exists, its list is empty)."""
+    feed = _feed()
+    entity = feed.entity.add()
+    entity.id = "tm-1"
+    tm = entity.trip_modifications
+    st = tm.selected_trips.add()
+    st.trip_ids.append("trip-1")
+    st.trip_ids.append("trip-2")
+    st.shape_id = "shape-detour-1"
+    tm.selected_trips.add().trip_ids.append("trip-3")  # no shape_id
+    tm.start_times.append("08:00:00")
+    tm.start_times.append("08:30:00")
+    tm.service_dates.append("20260701")
+    m = tm.modifications.add()
+    m.start_stop_selector.stop_sequence = 5
+    m.end_stop_selector.stop_id = "stop-b"
+    m.propagated_modification_delay = 0  # explicit zero must be captured
+    m.service_alert_id = "alert-1"
+    m.last_modified_time = 1_754_000_060
+    rs = m.replacement_stops.add()
+    rs.stop_id = "stop-new"  # travel_time_to_stop unset
+    tm.modifications.add()  # everything unset
+
+    (record,) = extract_trip_modifications(feed, "f.pb", "u", None)
+
+    assert json.loads(record["selected_trips_json"]) == [
+        {"trip_ids": ["trip-1", "trip-2"], "shape_id": "shape-detour-1"},
+        {"trip_ids": ["trip-3"], "shape_id": None},
+    ]
+    assert json.loads(record["start_times_json"]) == ["08:00:00", "08:30:00"]
+    assert json.loads(record["service_dates_json"]) == ["20260701"]
+    assert json.loads(record["modifications_json"]) == [
+        {
+            "start_stop_selector": {"stop_sequence": 5, "stop_id": None},
+            "end_stop_selector": {"stop_sequence": None, "stop_id": "stop-b"},
+            "propagated_modification_delay": 0,
+            "replacement_stops": [{"travel_time_to_stop": None, "stop_id": "stop-new"}],
+            "service_alert_id": "alert-1",
+            "last_modified_time": 1_754_000_060,
+        },
+        {
+            "start_stop_selector": None,
+            "end_stop_selector": None,
+            "propagated_modification_delay": None,
+            "replacement_stops": [],
+            "service_alert_id": None,
+            "last_modified_time": None,
+        },
+    ]
+
+
+def test_trip_modifications_empty_repeated_fields_are_null() -> None:
+    """A present-but-empty TripModifications yields NULL in all four JSON
+    columns — never "[]"."""
+    feed = _feed()
+    entity = feed.entity.add()
+    entity.id = "tm-empty"
+    entity.trip_modifications.SetInParent()
+
+    (record,) = extract_trip_modifications(feed, "f.pb", "u", None)
+
+    assert record["entity_id"] == "tm-empty"
+    assert record["selected_trips_json"] is None
+    assert record["start_times_json"] is None
+    assert record["service_dates_json"] is None
+    assert record["modifications_json"] is None
+
+
+def test_shape_unset_fields_are_null() -> None:
+    feed = _feed()
+    entity = feed.entity.add()
+    entity.id = "shape-empty"
+    entity.shape.SetInParent()
+
+    (record,) = extract_shapes(feed, "f.pb", "u", None)
+
+    assert record["entity_id"] == "shape-empty"
+    assert record["shape_id"] is None
+    assert record["encoded_polyline"] is None
+
+
+def test_stop_unset_fields_are_null() -> None:
+    feed = _feed()
+    entity = feed.entity.add()
+    entity.id = "stop-empty"
+    entity.stop.SetInParent()
+
+    (record,) = extract_stops(feed, "f.pb", "u", None)
+
+    assert record["entity_id"] == "stop-empty"
+    payload_keys = set(record) - {
+        "source_file",
+        "feed_url",
+        "feed_timestamp",
+        "fetch_timestamp",
+        "entity_id",
+        "feed_version",
+        "incrementality",
+        "is_deleted",
+    }
+    assert payload_keys, "stop record has no payload columns?"
+    for key in payload_keys:
+        assert record[key] is None, f"{key} should be NULL on an empty Stop"
+
+
+def test_stop_translations_capture_all_languages() -> None:
+    """Full-fidelity TranslatedString capture: every translation survives in
+    publisher order with its language tag (missing language -> JSON null) —
+    the keep-first loss #98 documents for service_alerts must not exist
+    here."""
+    feed = _feed()
+    entity = feed.entity.add()
+    entity.id = "stop-multilang"
+    stop = entity.stop
+    stop.stop_name.translation.add(text="Parada provisional", language="es")
+    stop.stop_name.translation.add(text="Temporary stop", language="en")
+    stop.stop_code.translation.add(text="1234")  # no language tag
+
+    (record,) = extract_stops(feed, "f.pb", "u", None)
+
+    assert json.loads(record["stop_name_translations_json"]) == [
+        {"text": "Parada provisional", "language": "es"},
+        {"text": "Temporary stop", "language": "en"},
+    ]
+    assert json.loads(record["stop_code_translations_json"]) == [{"text": "1234", "language": None}]
+    assert record["tts_stop_name_translations_json"] is None
+
+
+def test_extractors_select_only_their_entity_type() -> None:
+    """One feed carrying all six entity types: each extractor returns
+    exactly its own entity — the mixed-entity reality of Madison/BBB
+    trip_updates feeds (2026-08-04 census)."""
+    feed = _feed()
+    e = feed.entity.add()
+    e.id = "vp-1"
+    e.vehicle.position.latitude = 1.5
+    e.vehicle.position.longitude = 2.5
+    e = feed.entity.add()
+    e.id = "tu-1"
+    e.trip_update.trip.trip_id = "trip-1"
+    e = feed.entity.add()
+    e.id = "sa-1"
+    e.alert.header_text.translation.add(text="detour")
+    e = feed.entity.add()
+    e.id = "tm-1"
+    e.trip_modifications.selected_trips.add().trip_ids.append("trip-1")
+    e = feed.entity.add()
+    e.id = "shape-1"
+    e.shape.shape_id = "sh-1"
+    e = feed.entity.add()
+    e.id = "stop-1"
+    e.stop.stop_id = "st-1"
+
+    for extractor, expected_id in (
+        (extract_vehicle_positions, "vp-1"),
+        (extract_trip_updates, "tu-1"),
+        (extract_service_alerts, "sa-1"),
+        (extract_trip_modifications, "tm-1"),
+        (extract_shapes, "shape-1"),
+        (extract_stops, "stop-1"),
+    ):
+        records = list(extractor(feed, "f.pb", "u", None))
+        assert [r["entity_id"] for r in records] == [expected_id], extractor.__name__

--- a/tests/dagster/test_field_coverage.py
+++ b/tests/dagster/test_field_coverage.py
@@ -24,6 +24,9 @@ from google.transit import gtfs_realtime_pb2
 
 from dagster_pipeline.defs.assets.schemas import (
     SERVICE_ALERTS_SCHEMA,
+    SHAPES_SCHEMA,
+    STOPS_SCHEMA,
+    TRIP_MODIFICATIONS_SCHEMA,
     TRIP_UPDATES_SCHEMA,
     VEHICLE_POSITIONS_SCHEMA,
 )
@@ -32,6 +35,9 @@ SCHEMAS = {
     "vehicle_positions": VEHICLE_POSITIONS_SCHEMA,
     "trip_updates": TRIP_UPDATES_SCHEMA,
     "service_alerts": SERVICE_ALERTS_SCHEMA,
+    "trip_modifications": TRIP_MODIFICATIONS_SCHEMA,
+    "shapes": SHAPES_SCHEMA,
+    "stops": STOPS_SCHEMA,
 }
 
 # Columns not produced from any proto field: pipeline provenance metadata.
@@ -39,17 +45,9 @@ SYNTHESIZED_COLUMNS = {"source_file", "feed_url", "fetch_timestamp"}
 
 # Whole subtrees dropped as a unit; the walk does not descend into them.
 # Every entry must name a reason (and an issue where a decision is pending).
-DROPPED_SUBTREES: dict[str, str] = {
-    # NOT field drops — whole entity types outside the three archived tables.
-    # The 2026-08-04 census found Madison Metro and Big Blue Bus already
-    # publishing these (shape 316 / trip_modifications 312 / stop 90 entities
-    # in a 568-file sample); capturing each means a new table.
-    "entity.shape": "entity type outside the three archived tables (census: PUBLISHED; #96)",
-    "entity.stop": "entity type outside the three archived tables (census: PUBLISHED; #97)",
-    "entity.trip_modifications": (
-        "entity type outside the three archived tables (census: PUBLISHED; #95)"
-    ),
-}
+# Empty since #95/#96/#97 landed the shape/stop/trip_modifications tables —
+# every entity type the bindings know is captured.
+DROPPED_SUBTREES: dict[str, str] = {}
 
 # Leaf dispositions: path -> list of "table.column" targets, or a
 # "DROP: reason" string. A path may feed multiple columns.
@@ -62,22 +60,34 @@ MANIFEST: dict[str, Disposition] = {
         "vehicle_positions.incrementality",
         "trip_updates.incrementality",
         "service_alerts.incrementality",
+        "trip_modifications.incrementality",
+        "shapes.incrementality",
+        "stops.incrementality",
     ],
     "header.timestamp": [
         "vehicle_positions.feed_timestamp",
         "trip_updates.feed_timestamp",
         "service_alerts.feed_timestamp",
+        "trip_modifications.feed_timestamp",
+        "shapes.feed_timestamp",
+        "stops.feed_timestamp",
     ],
     "header.feed_version": [
         "vehicle_positions.feed_version",
         "trip_updates.feed_version",
         "service_alerts.feed_version",
+        "trip_modifications.feed_version",
+        "shapes.feed_version",
+        "stops.feed_version",
     ],
     # ---- FeedEntity ----
     "entity.id": [
         "vehicle_positions.entity_id",
         "trip_updates.entity_id",
         "service_alerts.entity_id",
+        "trip_modifications.entity_id",
+        "shapes.entity_id",
+        "stops.entity_id",
     ],
     # Captured on payload-bearing entities (MTA sets it explicitly, census
     # 2026-08-04); bare deletion tombstones (id + is_deleted, no payload) are
@@ -87,6 +97,9 @@ MANIFEST: dict[str, Disposition] = {
         "vehicle_positions.is_deleted",
         "trip_updates.is_deleted",
         "service_alerts.is_deleted",
+        "trip_modifications.is_deleted",
+        "shapes.is_deleted",
+        "stops.is_deleted",
     ],
     # ---- VehiclePosition ----
     "entity.vehicle.trip.trip_id": ["vehicle_positions.trip_id"],
@@ -275,6 +288,65 @@ MANIFEST: dict[str, Disposition] = {
     "entity.alert.image_alternative_text.translation.language": (
         "DROP: keep-first translation (#91 decision; multi-language capture: #98)"
     ),
+    # ---- TripModifications (#95) ----
+    # Entity/message grain: repeated structures JSON-encoded whole
+    "entity.trip_modifications.selected_trips.trip_ids": ["trip_modifications.selected_trips_json"],
+    "entity.trip_modifications.selected_trips.shape_id": ["trip_modifications.selected_trips_json"],
+    "entity.trip_modifications.start_times": ["trip_modifications.start_times_json"],
+    "entity.trip_modifications.service_dates": ["trip_modifications.service_dates_json"],
+    "entity.trip_modifications.modifications.start_stop_selector.stop_sequence": [
+        "trip_modifications.modifications_json"
+    ],
+    "entity.trip_modifications.modifications.start_stop_selector.stop_id": [
+        "trip_modifications.modifications_json"
+    ],
+    "entity.trip_modifications.modifications.end_stop_selector.stop_sequence": [
+        "trip_modifications.modifications_json"
+    ],
+    "entity.trip_modifications.modifications.end_stop_selector.stop_id": [
+        "trip_modifications.modifications_json"
+    ],
+    "entity.trip_modifications.modifications.propagated_modification_delay": [
+        "trip_modifications.modifications_json"
+    ],
+    "entity.trip_modifications.modifications.replacement_stops.travel_time_to_stop": [
+        "trip_modifications.modifications_json"
+    ],
+    "entity.trip_modifications.modifications.replacement_stops.stop_id": [
+        "trip_modifications.modifications_json"
+    ],
+    "entity.trip_modifications.modifications.service_alert_id": [
+        "trip_modifications.modifications_json"
+    ],
+    "entity.trip_modifications.modifications.last_modified_time": [
+        "trip_modifications.modifications_json"
+    ],
+    # ---- Shape (#96) ----
+    "entity.shape.shape_id": ["shapes.shape_id"],
+    "entity.shape.encoded_polyline": ["shapes.encoded_polyline"],
+    # ---- Stop (#97) ----
+    # TranslatedStrings captured full-fidelity as [{"text","language"},...]
+    # JSON — including .language, unlike the service_alerts keep-first drops
+    "entity.stop.stop_id": ["stops.stop_id"],
+    "entity.stop.stop_code.translation.text": ["stops.stop_code_translations_json"],
+    "entity.stop.stop_code.translation.language": ["stops.stop_code_translations_json"],
+    "entity.stop.stop_name.translation.text": ["stops.stop_name_translations_json"],
+    "entity.stop.stop_name.translation.language": ["stops.stop_name_translations_json"],
+    "entity.stop.tts_stop_name.translation.text": ["stops.tts_stop_name_translations_json"],
+    "entity.stop.tts_stop_name.translation.language": ["stops.tts_stop_name_translations_json"],
+    "entity.stop.stop_desc.translation.text": ["stops.stop_desc_translations_json"],
+    "entity.stop.stop_desc.translation.language": ["stops.stop_desc_translations_json"],
+    "entity.stop.stop_lat": ["stops.stop_lat"],
+    "entity.stop.stop_lon": ["stops.stop_lon"],
+    "entity.stop.zone_id": ["stops.zone_id"],
+    "entity.stop.stop_url.translation.text": ["stops.stop_url_translations_json"],
+    "entity.stop.stop_url.translation.language": ["stops.stop_url_translations_json"],
+    "entity.stop.parent_station": ["stops.parent_station"],
+    "entity.stop.stop_timezone": ["stops.stop_timezone"],
+    "entity.stop.wheelchair_boarding": ["stops.wheelchair_boarding"],
+    "entity.stop.level_id": ["stops.level_id"],
+    "entity.stop.platform_code.translation.text": ["stops.platform_code_translations_json"],
+    "entity.stop.platform_code.translation.language": ["stops.platform_code_translations_json"],
 }
 
 

--- a/tests/dagster/test_field_extraction.py
+++ b/tests/dagster/test_field_extraction.py
@@ -53,6 +53,9 @@ def test_bindings_expose_required_fields() -> None:
 # plausibly meet (spec-1.0/2.0-era fields) — deliberately NOT in
 # REQUIRED_BINDINGS_FIELDS, per its "long-stable fields" exclusion.
 # Kept disjoint from the guard: promote an entry there when in doubt.
+# Name-level conflation cuts both ways: once ANY message promotes a name
+# into the guard (e.g. Stop.stop_id, 2.2-gated), the name leaves this list
+# even though ancient same-named fields (VehiclePosition.stop_id) exist.
 STABLE_HASFIELD_TARGETS = frozenset(
     {
         "agency_id",
@@ -71,6 +74,7 @@ STABLE_HASFIELD_TARGETS = frozenset(
         "header_text",
         "incrementality",
         "is_deleted",
+        "language",
         "license_plate",
         "odometer",
         "position",
@@ -80,8 +84,6 @@ STABLE_HASFIELD_TARGETS = frozenset(
         "severity_level",
         "speed",
         "start",
-        "stop_id",
-        "stop_sequence",
         "time",
         "timestamp",
         "trip",

--- a/tests/dagster/test_field_extraction.py
+++ b/tests/dagster/test_field_extraction.py
@@ -19,11 +19,17 @@ from dagster_pipeline.defs.assets.compaction import (
     INFORMED_ENTITY_KEYS,
     STOP_TIME_UPDATE_KEYS,
     extract_service_alerts,
+    extract_shapes,
+    extract_stops,
+    extract_trip_modifications,
     extract_trip_updates,
     extract_vehicle_positions,
 )
 from dagster_pipeline.defs.assets.schemas import (
     SERVICE_ALERTS_SCHEMA,
+    SHAPES_SCHEMA,
+    STOPS_SCHEMA,
+    TRIP_MODIFICATIONS_SCHEMA,
     TRIP_UPDATES_SCHEMA,
     VEHICLE_POSITIONS_SCHEMA,
 )
@@ -480,6 +486,22 @@ def test_record_keys_match_schemas_exactly() -> None:
         (SERVICE_ALERTS_SCHEMA, list(extract_service_alerts(sa_no_ie_feed, "f", "u", None)))
     )
 
+    entity_feed = _feed()
+    e = entity_feed.entity.add()
+    e.id = "tm"
+    e.trip_modifications.selected_trips.add().shape_id = "sh"
+    e = entity_feed.entity.add()
+    e.id = "sh"
+    e.shape.shape_id = "sh"
+    e = entity_feed.entity.add()
+    e.id = "st"
+    e.stop.stop_id = "s1"
+    cases.append(
+        (TRIP_MODIFICATIONS_SCHEMA, list(extract_trip_modifications(entity_feed, "f", "u", None)))
+    )
+    cases.append((SHAPES_SCHEMA, list(extract_shapes(entity_feed, "f", "u", None))))
+    cases.append((STOPS_SCHEMA, list(extract_stops(entity_feed, "f", "u", None))))
+
     for schema, records in cases:
         assert records, "each case must yield at least one record"
         for record in records:
@@ -681,6 +703,54 @@ def test_base_record_keys_disjoint_from_child_key_tuples() -> None:
     )
 
 
+def _populated_tm_entity(entity: gtfs_realtime_pb2.FeedEntity) -> None:
+    entity.is_deleted = False
+    tm = entity.trip_modifications
+    st = tm.selected_trips.add()
+    st.trip_ids.append("trip-1")
+    st.trip_ids.append("trip-2")
+    st.shape_id = "shape-detour-1"
+    tm.start_times.append("08:00:00")
+    tm.service_dates.append("20260701")
+    m = tm.modifications.add()
+    m.start_stop_selector.stop_sequence = 5
+    m.start_stop_selector.stop_id = "stop-a"
+    m.end_stop_selector.stop_sequence = 9
+    m.end_stop_selector.stop_id = "stop-b"
+    m.propagated_modification_delay = 120
+    rs = m.replacement_stops.add()
+    rs.travel_time_to_stop = 60
+    rs.stop_id = "stop-new"
+    m.service_alert_id = "alert-1"
+    m.last_modified_time = 1_754_000_060
+
+
+def _populated_shape_entity(entity: gtfs_realtime_pb2.FeedEntity) -> None:
+    entity.is_deleted = False
+    entity.shape.shape_id = "shape-detour-1"
+    entity.shape.encoded_polyline = "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+
+
+def _populated_stop_entity(entity: gtfs_realtime_pb2.FeedEntity) -> None:
+    entity.is_deleted = False
+    stop = entity.stop
+    stop.stop_id = "stop-new"
+    stop.stop_code.translation.add(text="1234", language="en")
+    stop.stop_name.translation.add(text="Detour Stop", language="en")
+    stop.tts_stop_name.translation.add(text="Detour Stop", language="en")
+    stop.stop_desc.translation.add(text="Temporary detour stop", language="en")
+    # Non-integral floats on purpose (see _populated_vp_feed)
+    stop.stop_lat = 43.1
+    stop.stop_lon = -89.4
+    stop.zone_id = "zone-1"
+    stop.stop_url.translation.add(text="https://example.com/stop", language="en")
+    stop.parent_station = "station-1"
+    stop.stop_timezone = "America/Chicago"
+    stop.wheelchair_boarding = gtfs_realtime_pb2.Stop.AVAILABLE
+    stop.level_id = "level-1"
+    stop.platform_code.translation.add(text="A", language="en")
+
+
 def test_populated_records_have_no_nulls_and_round_trip() -> None:
     """Feed every schema column a real value and round-trip through Arrow.
 
@@ -721,10 +791,29 @@ def test_populated_records_have_no_nulls_and_round_trip() -> None:
     _populated_sa_entity(e, with_ie=False)
     sa_records = list(extract_service_alerts(sa_feed, "f", "u", ts))
 
+    entity_feed = _feed()
+    entity_feed.header.feed_version = "producer-v1"
+    entity_feed.header.incrementality = gtfs_realtime_pb2.FeedHeader.FULL_DATASET
+    e = entity_feed.entity.add()
+    e.id = "tm-full"
+    _populated_tm_entity(e)
+    e = entity_feed.entity.add()
+    e.id = "shape-full"
+    _populated_shape_entity(e)
+    e = entity_feed.entity.add()
+    e.id = "stop-full"
+    _populated_stop_entity(e)
+    tm_records = list(extract_trip_modifications(entity_feed, "f", "u", ts))
+    shape_records = list(extract_shapes(entity_feed, "f", "u", ts))
+    stop_records = list(extract_stops(entity_feed, "f", "u", ts))
+
     for table_name, full_record in (
         ("vehicle_positions", vp_records[0]),
         ("trip_updates", tu_records[0]),
         ("service_alerts", sa_records[0]),
+        ("trip_modifications", tm_records[0]),
+        ("shapes", shape_records[0]),
+        ("stops", stop_records[0]),
     ):
         nones = {k for k, v in full_record.items() if v is None}
         assert not nones, f"{table_name} populated record has NULLs: {nones}"
@@ -740,6 +829,9 @@ def test_populated_records_have_no_nulls_and_round_trip() -> None:
         (VEHICLE_POSITIONS_SCHEMA, vp_records),
         (TRIP_UPDATES_SCHEMA, tu_records),
         (SERVICE_ALERTS_SCHEMA, sa_records),
+        (TRIP_MODIFICATIONS_SCHEMA, tm_records),
+        (SHAPES_SCHEMA, shape_records),
+        (STOPS_SCHEMA, stop_records),
     ):
         table = pa.Table.from_pylist(records, schema=schema)
         assert table.num_rows == len(records)
@@ -763,6 +855,9 @@ def test_bigquery_ddl_matches_schemas() -> None:
         ("vehicle_positions", VEHICLE_POSITIONS_SCHEMA),
         ("trip_updates", TRIP_UPDATES_SCHEMA),
         ("service_alerts", SERVICE_ALERTS_SCHEMA),
+        ("trip_modifications", TRIP_MODIFICATIONS_SCHEMA),
+        ("shapes", SHAPES_SCHEMA),
+        ("stops", STOPS_SCHEMA),
     ):
         block = re.search(
             rf'resource "google_bigquery_table" "{table_id}".*?schema = jsonencode\(\[(.*?)\]\)',

--- a/tf/bigquery.tf
+++ b/tf/bigquery.tf
@@ -211,6 +211,123 @@ resource "google_bigquery_table" "service_alerts" {
   ])
 }
 
+# Trip Modifications - entity/message grain, repeated structures as JSON (#95)
+# Extracted from trip_updates raw feeds in the same compaction pass;
+# entity_id is the join target of {trip_updates,vehicle_positions}
+# .modified_trip_modifications_id
+resource "google_bigquery_table" "trip_modifications" {
+  dataset_id                   = google_bigquery_dataset.gtfs_rt.dataset_id
+  table_id                     = "trip_modifications"
+  deletion_protection          = false
+  ignore_auto_generated_schema = true
+
+  external_data_configuration {
+    source_format = "PARQUET"
+    autodetect    = false
+    source_uris   = ["gs://${google_storage_bucket.parquet.name}/trip_modifications/*"]
+
+    hive_partitioning_options {
+      mode                     = "CUSTOM"
+      source_uri_prefix        = "gs://${google_storage_bucket.parquet.name}/trip_modifications/{date:DATE}/{base64url:STRING}"
+      require_partition_filter = false
+    }
+  }
+
+  schema = jsonencode([
+    { name = "source_file", type = "STRING", mode = "REQUIRED" },
+    { name = "feed_url", type = "STRING", mode = "REQUIRED" },
+    { name = "feed_timestamp", type = "INT64", mode = "NULLABLE" },
+    { name = "fetch_timestamp", type = "TIMESTAMP", mode = "NULLABLE" },
+    { name = "entity_id", type = "STRING", mode = "REQUIRED" },
+    { name = "selected_trips_json", type = "STRING", mode = "NULLABLE" },
+    { name = "start_times_json", type = "STRING", mode = "NULLABLE" },
+    { name = "service_dates_json", type = "STRING", mode = "NULLABLE" },
+    { name = "modifications_json", type = "STRING", mode = "NULLABLE" },
+    { name = "feed_version", type = "STRING", mode = "NULLABLE" },
+    { name = "incrementality", type = "INT64", mode = "NULLABLE" },
+    { name = "is_deleted", type = "BOOL", mode = "NULLABLE" },
+  ])
+}
+
+# Shapes - detour replacement geometry entities (#96)
+resource "google_bigquery_table" "shapes" {
+  dataset_id                   = google_bigquery_dataset.gtfs_rt.dataset_id
+  table_id                     = "shapes"
+  deletion_protection          = false
+  ignore_auto_generated_schema = true
+
+  external_data_configuration {
+    source_format = "PARQUET"
+    autodetect    = false
+    source_uris   = ["gs://${google_storage_bucket.parquet.name}/shapes/*"]
+
+    hive_partitioning_options {
+      mode                     = "CUSTOM"
+      source_uri_prefix        = "gs://${google_storage_bucket.parquet.name}/shapes/{date:DATE}/{base64url:STRING}"
+      require_partition_filter = false
+    }
+  }
+
+  schema = jsonencode([
+    { name = "source_file", type = "STRING", mode = "REQUIRED" },
+    { name = "feed_url", type = "STRING", mode = "REQUIRED" },
+    { name = "feed_timestamp", type = "INT64", mode = "NULLABLE" },
+    { name = "fetch_timestamp", type = "TIMESTAMP", mode = "NULLABLE" },
+    { name = "entity_id", type = "STRING", mode = "REQUIRED" },
+    { name = "shape_id", type = "STRING", mode = "NULLABLE" },
+    { name = "encoded_polyline", type = "STRING", mode = "NULLABLE" },
+    { name = "feed_version", type = "STRING", mode = "NULLABLE" },
+    { name = "incrementality", type = "INT64", mode = "NULLABLE" },
+    { name = "is_deleted", type = "BOOL", mode = "NULLABLE" },
+  ])
+}
+
+# Stops - ad-hoc/replacement stop definition entities (#97); TranslatedString
+# fields captured full-fidelity as [{"text","language"},...] JSON (#98)
+resource "google_bigquery_table" "stops" {
+  dataset_id                   = google_bigquery_dataset.gtfs_rt.dataset_id
+  table_id                     = "stops"
+  deletion_protection          = false
+  ignore_auto_generated_schema = true
+
+  external_data_configuration {
+    source_format = "PARQUET"
+    autodetect    = false
+    source_uris   = ["gs://${google_storage_bucket.parquet.name}/stops/*"]
+
+    hive_partitioning_options {
+      mode                     = "CUSTOM"
+      source_uri_prefix        = "gs://${google_storage_bucket.parquet.name}/stops/{date:DATE}/{base64url:STRING}"
+      require_partition_filter = false
+    }
+  }
+
+  schema = jsonencode([
+    { name = "source_file", type = "STRING", mode = "REQUIRED" },
+    { name = "feed_url", type = "STRING", mode = "REQUIRED" },
+    { name = "feed_timestamp", type = "INT64", mode = "NULLABLE" },
+    { name = "fetch_timestamp", type = "TIMESTAMP", mode = "NULLABLE" },
+    { name = "entity_id", type = "STRING", mode = "REQUIRED" },
+    { name = "stop_id", type = "STRING", mode = "NULLABLE" },
+    { name = "stop_code_translations_json", type = "STRING", mode = "NULLABLE" },
+    { name = "stop_name_translations_json", type = "STRING", mode = "NULLABLE" },
+    { name = "tts_stop_name_translations_json", type = "STRING", mode = "NULLABLE" },
+    { name = "stop_desc_translations_json", type = "STRING", mode = "NULLABLE" },
+    { name = "stop_lat", type = "FLOAT64", mode = "NULLABLE" },
+    { name = "stop_lon", type = "FLOAT64", mode = "NULLABLE" },
+    { name = "zone_id", type = "STRING", mode = "NULLABLE" },
+    { name = "stop_url_translations_json", type = "STRING", mode = "NULLABLE" },
+    { name = "parent_station", type = "STRING", mode = "NULLABLE" },
+    { name = "stop_timezone", type = "STRING", mode = "NULLABLE" },
+    { name = "wheelchair_boarding", type = "INT64", mode = "NULLABLE" },
+    { name = "level_id", type = "STRING", mode = "NULLABLE" },
+    { name = "platform_code_translations_json", type = "STRING", mode = "NULLABLE" },
+    { name = "feed_version", type = "STRING", mode = "NULLABLE" },
+    { name = "incrementality", type = "INT64", mode = "NULLABLE" },
+    { name = "is_deleted", type = "BOOL", mode = "NULLABLE" },
+  ])
+}
+
 # --- GTFS Schedule tables ---
 # Schedule data is stored as exploded parquet per feed version.
 # Each table uses autodetect since GTFS columns are all strings.


### PR DESCRIPTION
Closes #95, closes #96, closes #97.

**Stacked on #94** (base is `feat/rt-field-extraction` for a clean review diff; GitHub retargets to `develop` when #94 merges and its branch is deleted — or retarget manually). Merge order: #94 first, then this. Both target the v0.9.3 release (#76).

## What

The 2026-08-04 census found Madison Metro and Big Blue Bus publishing `trip_modifications`, `shape`, and `stop` entities inside their trip_updates feed URLs — fetched, archived, then silently dropped at compaction. This adds three tables so we parse everything we get:

- **Entity/message grain** — one row per FeedEntity, repeated structures JSON-encoded whole (`selected_trips_json`, `start_times_json`, `service_dates_json`, `modifications_json`); unnesting is a downstream transform concern. This deliberately does NOT extend the original tables' denormalized grain — see the new DESIGN.md entry recording that that grain was set without articulated rationale and is retained only because changing it would be disruptive.
- **Stops' six TranslatedString fields are full-fidelity `*_translations_json`** from day one (`[{"text","language"},…]`, publisher order) — no keep-first selection baked in, #98-neutral, no migration ever owed.
- **One-pass extraction** (#95 decision): `compact_single_feed` generalized to `compact_feed_tables`; the trip_updates asset is now a non-subsettable `@multi_asset` with four outputs from a single download+parse of the same raw files. Parse failures skip the file for every table consistently; conversion failures name file AND table; zero-record outputs upload nothing.
- `REQUIRED_BINDINGS_FIELDS` covers the new HasField surfaces (pre-2.2 bindings would ValueError into the swallowed empty-partition class).
- Manifest test: `DROPPED_SUBTREES` is now **empty** — every leaf of every entity type the bindings know is dispositioned.
- BigQuery external tables for the three new prefixes (order-locked, DDL-parity-tested).
- Inventory + reconciliation-dashboard path regexes pinned to the three primary prefixes so the new tables' rows don't silently pollute per-feed counts/expectations (caught by pre-push adversarial review).

## Verification

- 239 tests, ruff, mypy strict green; `dg check defs` loads
- Targeted `tofu plan`: 3 to add, 0 to change, 0 to destroy
- **Empty-prefix apply risk disproven**: probe external table (CUSTOM hive + explicit schema) created cleanly over the empty `trip_modifications/` prefix, then deleted — deploy-time `tofu apply` cannot hit "matched no files"
- **Real-data validation** (2026-08-04 snapshots, read-only): Madison 34 trip_modifications / 34 shapes / 11 stops per snapshot; BBB 4/4/0; live `service_alert_id` join keys (`CWDetour-…`), multi-week `service_dates`, real replacement-stop definitions; Arrow round-trips clean. Producer quirk recorded in the plan: BBB publishes `last_modified_time` in milliseconds — captured verbatim.

Plan: `plans/entity-type-capture.md` (all validation criteria checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)