### PR TITLE
docs(specs): amendments from first /audit-spec-drift run

### DIFF
--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -46,7 +46,9 @@ agencies.yaml (Secret Manager) ──▶ feeds_metadata ──▶ feeds.parquet 
   yesterday's raw prefixes per feed type, registers unseen feeds as dynamic
   partitions, and requests runs for discovered feed+date combinations. There
   is no static feed registry in the pipeline; the raw bucket is the source of
-  feed existence.
+  feed existence. The sensor ships `default_status=STOPPED` (safe-rollout
+  choice); whether it is running is an operational fact of the live Dagster
+  instance, not derivable from code.
 - **Daily compaction**: three per-type schedules (`vehicle_positions_schedule`,
   `trip_updates_schedule`, `service_alerts_schedule`) fire at 02:00 UTC and
   request one run per *known* (already-registered) feed partition for

--- a/specs/behaviors/archiving.md
+++ b/specs/behaviors/archiving.md
@@ -55,6 +55,11 @@ writer, health/metrics server.
   etag / last-modified / content-type / content-length headers).
 - Compaction depends on `fetch_timestamp` in the sidecar; a missing or invalid
   sidecar degrades that column to NULL downstream, it does not block capture.
+- Uploads retry transient I/O errors only (GCS client errors, timeouts,
+  connection errors) — up to 3 attempts with exponential backoff (1s base,
+  10s cap). Exhaustion is logged as `upload_error` and the snapshot is
+  dropped like any other missed tick
+  ([principle](../principles.md#missed-data-has-no-value-late)).
 
 ## Observability surface
 
@@ -64,9 +69,9 @@ The service exposes, on one port (`HEALTH_PORT`, default 8080):
   feed counts
 - `GET /health/feeds` — per-feed status detail
 - `GET /ready` — readiness
-- `GET /metrics` — Prometheus: fetch/upload counters (success/error, per feed,
-  type, and agency), duration and size histograms, active-feed and job gauges,
-  last-fetch timestamps
+- `GET /metrics` — Prometheus scrape target (OpenMetrics exposition format):
+  fetch/upload counters (success/error, per feed, type, and agency), duration
+  and size histograms, active-feed and job gauges, last-fetch timestamps
 
 Structured logs (structlog; JSON in production) record every fetch success and
 failure with feed identity, timing, and error context.

--- a/specs/behaviors/compaction.md
+++ b/specs/behaviors/compaction.md
@@ -36,7 +36,11 @@ field-coverage manifest tests (`tests/dagster/test_field_coverage.py`).
   genuinely empty input
   ([principle](../principles.md#fail-loud-on-total-failure-tolerate-partial-failure)).
 - **Parquet conversion/write failure**: fail the partition loudly, naming the
-  offending output; never upload a partial buffer.
+  offending output; never upload a partial buffer. One deliberate carve-out:
+  `MemoryError` re-raises unwrapped (no file/table naming) — OOM is a
+  resource condition, not a schema bug, and must not send the operator
+  chasing an innocent input file (#92 watch item; the no-partial-upload
+  guarantee still holds).
 - **Zero-record table**: uploads nothing — no file, never an empty file.
 
 ## Re-materialization and overwrite semantics


### PR DESCRIPTION
The first `/audit-spec-drift` run against the freshly-merged specs (#102) verified the extraction clean on all contract surfaces and returned four small accuracy findings plus one real bug. This PR lands the four spec amendments; the bug is filed as #104.

## Amendments (all describe already-shipped behavior — code conforms at merge, so no plan file rides along)

- **`behaviors/archiving.md`** — specify the GCS upload retry (3 attempts, exponential backoff 1s→10s, transient I/O errors only, exhaustion drops the snapshot per missed-data-has-no-value-late)
- **`behaviors/archiving.md`** — note `/metrics` serves the OpenMetrics exposition format
- **`behaviors/compaction.md`** — document the deliberate `MemoryError` carve-out from the "fail loudly naming the offending output" guarantee (OOM is a resource condition, not a schema bug; #92 watch item; no-partial-upload still holds)
- **`architecture.md`** — note `feed_discovery_sensor` ships `default_status=STOPPED` and its live status is an operational fact (closing the gap `plans/adopt-specs.md` had flagged in Notes)

## Not in this PR

The audit's severe finding — all feeds' fetches serialize through one shared APScheduler task (`max_running_jobs=1` on the shared callable-derived Task), making `MAX_CONCURRENT` inert — is a **code** bug against the unchanged spec ("at most one concurrent run per feed; feeds fail independently"). Tracked as #104 with reproduction evidence; it deserves its own plan and regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)