### PR TITLE
fix(archiver): per-feed APScheduler tasks — feeds fetch concurrently

### DIFF
--- a/plans/fix-fetch-concurrency.md
+++ b/plans/fix-fetch-concurrency.md
@@ -1,0 +1,75 @@
+---
+status: in-progress
+depends: []
+specs:
+  - specs/behaviors/archiving.md
+issues: [104]
+---
+
+# Plan: Fix system-wide fetch serialization (per-feed APScheduler tasks)
+
+## Scope
+
+Bring the archiver's fetch concurrency into conformance with
+`specs/behaviors/archiving.md` ("At most one concurrent run per feed; feeds
+fail independently"): fetches for *different* feeds must run concurrently up
+to the `MAX_CONCURRENT` semaphore, while runs of the *same* feed never
+overlap.
+
+In scope: `src/gtfs_rt_archiver/scheduler.py` task registration; a regression
+test pinning cross-feed concurrency. Out of scope: stagger algorithm changes
+(#60), scheduler-health dashboards (#59), and any interval/misfire tuning —
+those follow once the fleet's real concurrent load profile is observable.
+
+## Implements
+
+- `specs/behaviors/archiving.md` — the Scheduling section's per-feed
+  concurrency rule and the Fetching section's `MAX_CONCURRENT` ceiling (which
+  is currently inert because nothing else ever runs in parallel).
+
+## Approach
+
+Root cause (#104): all feeds' schedules register the same module-level
+callable, and APScheduler v4 derives **Task** identity from the callable —
+so every feed shares one Task whose `max_running_jobs` defaults to 1,
+serializing the whole fleet.
+
+Fix: register a **per-feed task** before each `add_schedule` call —
+`configure_task(f"fetch-{feed.id}", func=_execute_scheduled_fetch,
+max_running_jobs=1)` — and point the schedule at that task id. The
+`max_running_jobs=1` cap then means what the spec means: one concurrent run
+*per feed*, with cross-feed parallelism governed by the fetch pool's
+semaphore.
+
+Regression test: real `AsyncScheduler`, N feeds with stagger patched to 0 so
+all schedules fire together, fetch job that tracks peak concurrency while
+sleeping; assert peak ≥ 2 (pre-fix behavior pins it at exactly 1).
+
+## Validation
+
+- [ ] Regression test demonstrates cross-feed concurrency > 1 under
+  simultaneous triggers (and fails against the pre-fix scheduler)
+- [ ] Per-feed no-overlap is still enforced (max_running_jobs=1 per feed task)
+- [ ] `uv run ruff check src/ tests/`, `uv run mypy src/`,
+  `uv run pytest tests/` all pass
+- [ ] Post-deploy (next release): fetch-latency/misfire metrics reviewed and
+  #51 (Big Blue Bus) re-checked for recovered vehicle positions
+
+## Risks / unknowns
+
+- **Thundering herd on restart** — parallel fetches were previously
+  impossible, so the md5 stagger has never been load-bearing. After this fix
+  a restart still spreads first fires across each feed's interval; watch the
+  fetch-duration histogram after deploy (#59 dashboards would make this
+  visible; #60 improves the spread).
+- **Downstream rate limits** — some agencies may throttle now that fetches
+  can actually overlap in time across their feeds; per-feed intervals are
+  unchanged, so sustained request rate is the same, only phase changes.
+
+## Notes
+
+(Populated at closeout.)
+
+## Follow-ups
+
+(Populated at closeout.)

--- a/plans/fix-fetch-concurrency.md
+++ b/plans/fix-fetch-concurrency.md
@@ -1,9 +1,10 @@
 ---
-status: in-progress
+status: done
 depends: []
 specs:
   - specs/behaviors/archiving.md
 issues: [104]
+pr: 106
 ---
 
 # Plan: Fix system-wide fetch serialization (per-feed APScheduler tasks)
@@ -47,11 +48,12 @@ sleeping; assert peak ≥ 2 (pre-fix behavior pins it at exactly 1).
 
 ## Validation
 
-- [ ] Regression test demonstrates cross-feed concurrency > 1 under
-  simultaneous triggers (and fails against the pre-fix scheduler)
-- [ ] Per-feed no-overlap is still enforced (max_running_jobs=1 per feed task)
-- [ ] `uv run ruff check src/ tests/`, `uv run mypy src/`,
-  `uv run pytest tests/` all pass
+- [x] Regression test demonstrates cross-feed concurrency > 1 under
+  simultaneous triggers (and fails against the pre-fix scheduler — verified
+  via `git stash`: peak pinned at 1 until timeout)
+- [x] Per-feed no-overlap is still enforced (max_running_jobs=1 per feed task)
+- [x] `uv run ruff check src/ tests/`, `uv run mypy src/`,
+  `uv run pytest tests/` all pass (246 passed)
 - [ ] Post-deploy (next release): fetch-latency/misfire metrics reviewed and
   #51 (Big Blue Bus) re-checked for recovered vehicle positions
 
@@ -68,8 +70,25 @@ sleeping; assert peak ≥ 2 (pre-fix behavior pins it at exactly 1).
 
 ## Notes
 
-(Populated at closeout.)
+- The post-deploy validation criterion is intentionally unchecked at merge:
+  it can only close after the next release ships this fix to Cloud Run. It
+  closes out via #51 (re-check Big Blue Bus) and the #59 dashboard work.
+- APScheduler subtlety worth remembering: `add_schedule(callable, id=...)`'s
+  `id` names the *schedule*; Task identity (which `max_running_jobs` scopes
+  to) comes from `callable_to_ref(callable)` unless a task is configured
+  explicitly. `configure_task(task_id, func=...)` + `add_schedule(task_id,
+  ...)` is the pattern for distinct tasks sharing one callable.
+- The bug made the md5 stagger non-load-bearing (serialization was the real
+  spacing); post-fix, stagger is what actually spreads load — raising #60's
+  priority.
 
 ## Follow-ups
 
-(Populated at closeout.)
+- Issue [#51](https://github.com/JarvusInnovations/gtfs-realtime-archiver/issues/51)
+  — re-check for recovered vehicle positions after the next release deploys
+  this fix.
+- Issue [#60](https://github.com/JarvusInnovations/gtfs-realtime-archiver/issues/60)
+  — rank-based staggering is now genuinely load-bearing (see Notes).
+- Issue [#59](https://github.com/JarvusInnovations/gtfs-realtime-archiver/issues/59)
+  — scheduler-health dashboard is where the post-deploy criterion gets
+  verified.

--- a/src/gtfs_rt_archiver/scheduler.py
+++ b/src/gtfs_rt_archiver/scheduler.py
@@ -149,8 +149,21 @@ class FeedScheduler:
             start_time = now + timedelta(seconds=offset)
             trigger = IntervalTrigger(seconds=feed.interval_seconds, start_time=start_time)
 
+            # Each feed needs its own Task: APScheduler derives Task identity
+            # from the callable, so registering _execute_scheduled_fetch
+            # directly would put every feed on ONE task whose
+            # max_running_jobs=1 default serializes fetches fleet-wide (#104).
+            # A per-feed task scopes that cap to the feed: no overlapping runs
+            # of the same feed, while cross-feed concurrency is bounded only
+            # by the fetch pool's MAX_CONCURRENT semaphore.
+            task_id = f"fetch-{feed.id}"
+            await self._scheduler.configure_task(
+                task_id,
+                func=_execute_scheduled_fetch,
+                max_running_jobs=1,
+            )
             await self._scheduler.add_schedule(
-                _execute_scheduled_fetch,
+                task_id,
                 trigger=trigger,
                 id=f"feed-{feed.id}",
                 kwargs={"scheduler_id": self._id, "feed_id": feed.id},

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -231,6 +231,54 @@ class TestFeedScheduler:
         assert len(calls) == 1
         assert calls[0] == feeds[0]
 
+    async def test_feeds_fetch_concurrently(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Regression test for #104: fetches must run concurrently across feeds.
+
+        Before the per-feed task fix, every feed's schedule shared one
+        APScheduler Task (identity derived from the shared callable) whose
+        max_running_jobs=1 default serialized all fetches fleet-wide, pinning
+        peak concurrency at exactly 1.
+        """
+        import asyncio
+        import contextlib
+
+        from gtfs_rt_archiver import scheduler as scheduler_module
+
+        # Fire all schedules at the same instant instead of staggered
+        monkeypatch.setattr(scheduler_module, "compute_start_offset", lambda *_: 0.0)
+
+        feeds = [make_feed(f"feed-{i}") for i in range(3)]
+        running = 0
+        peak = 0
+        all_overlapped = asyncio.Event()
+
+        async def fetch_job(_feed: FeedConfig, _scheduled_time: datetime) -> None:
+            nonlocal running, peak
+            running += 1
+            peak = max(peak, running)
+            if peak >= len(feeds):
+                all_overlapped.set()
+            await asyncio.sleep(1.0)
+            running -= 1
+
+        scheduler = FeedScheduler(
+            feeds=feeds,
+            fetch_job=fetch_job,
+            misfire_grace_time=10.0,  # Generous grace so slow CI can't drop ticks
+        )
+        await scheduler.start()
+        try:
+            # On timeout, fall through to the peak assertion for a precise message
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(all_overlapped.wait(), timeout=5.0)
+        finally:
+            await scheduler.stop(wait=True)
+
+        assert peak >= 2, (
+            f"Fetches serialized (peak concurrency {peak}); feeds must fetch "
+            "concurrently per specs/behaviors/archiving.md (#104)"
+        )
+
     async def test_is_running_reflects_scheduler_state(self, feeds: list[FeedConfig]) -> None:
         """Test is_running property reflects actual scheduler state."""
 


### PR DESCRIPTION
Fixes the system-wide fetch serialization found by the first `/audit-spec-drift` run and tracked in #104.

## Root cause

APScheduler v4 derives **Task** identity from the callable, not the schedule `id`. Every feed's schedule registered the same module-level `_execute_scheduled_fetch`, so the entire fleet shared one Task — and its `max_running_jobs=1` default serialized every fetch system-wide. The `MAX_CONCURRENT=100` semaphore could never hold more than one permit, and once sequential fleet fetch time approached the shortest interval (20s) minus the 5s misfire grace, ticks were silently dropped (plausible mechanism behind #51/#77 symptoms).

## Fix

Register a **per-feed task** (`configure_task(f"fetch-{feed.id}", func=_execute_scheduled_fetch, max_running_jobs=1)`) and point each schedule at it. The cap now means what `specs/behaviors/archiving.md` specifies: at most one concurrent run *per feed*, cross-feed concurrency bounded only by the fetch pool's semaphore. No spec change — this is pure code conformance to the existing spec.

## Verification

- New regression test `test_feeds_fetch_concurrently` (3 feeds, stagger patched to zero, real `AsyncScheduler`): **fails against the pre-fix scheduler** (peak concurrency pinned at 1 until timeout, verified via `git stash`) and passes in ~1s with the fix.
- Full gate: ruff ✅ · mypy ✅ · pytest 246 passed ✅

## Post-deploy follow-through (tracked in the plan)

Watch fetch-latency/misfire metrics after the next release and re-check #51 (Big Blue Bus vehicle positions) for recovery. Rate-limit risk is low: per-feed intervals are unchanged, only phase overlap changes.

Closes #104. Plan: `plans/fix-fetch-concurrency.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)